### PR TITLE
Add Localisation translations for French, Arabic, Persian, German, Spanish, Swahili, Turkish

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6,6 +6,12 @@
     },
     "%@ accounts" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Konten"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16,6 +22,12 @@
     },
     "Account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26,6 +38,12 @@
     },
     "Add Accounts to Vault" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten zu Vault hinzufügen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36,6 +54,12 @@
     },
     "Already got SMS code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SMS-Code bereits erhalten"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46,6 +70,12 @@
     },
     "Already have an account?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie haben bereits ein Konto?"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56,6 +86,12 @@
     },
     "Available Platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbare Plattformen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -66,6 +102,12 @@
     },
     "Bcc " : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bcc"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76,6 +118,12 @@
     },
     "Cc " : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cc"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -86,6 +134,12 @@
     },
     "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie die Plattform aus, für die Sie Konten sperren möchten. Auf dem nächsten Bildschirm können Sie auswählen, welches Konto für die Plattform widerrufen werden soll."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -96,6 +150,12 @@
     },
     "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -106,6 +166,12 @@
     },
     "Come back anytime" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jederzeit wiederkommen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -116,6 +182,12 @@
     },
     "Compose email" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-Mail verfassen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -126,6 +198,12 @@
     },
     "Compose for Platform" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compose für Plattform"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -136,6 +214,12 @@
     },
     "Compose Message" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nachricht verfassen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -147,6 +231,12 @@
     "Compose Post" : {
       "comment" : "Should \"Post\" be translated as \"Publier\"",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beitrag verfassen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -157,6 +247,12 @@
     },
     "composeBody" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "composeBody"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -167,6 +263,12 @@
     },
     "Continue" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weiter"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -177,6 +279,12 @@
     },
     "Continue Deleting" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschung fortsetzen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -187,6 +295,12 @@
     },
     "Create a new RelaySMS Vault account or signup to your existing." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen Sie ein neues RelaySMS Vault-Konto oder melden Sie sich bei Ihrem bestehenden Konto an."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -197,6 +311,12 @@
     },
     "Create Account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto erstellen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -207,6 +327,12 @@
     },
     "Create new account or log into existing one to begin sending messages from stored online platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen Sie ein neues Konto oder melden Sie sich bei einem bestehenden Konto an, um Nachrichten von gespeicherten Online-Plattformen zu versenden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -224,7 +350,8 @@
             "value" : "relaysms"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "default_oauth_path" : {
       "extractionState" : "manual",
@@ -235,10 +362,17 @@
             "value" : "oauth.afkanerd.com/platforms/gmail/protocols/oauth2/redirect_codes/ios/"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "Delete Account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto löschen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -249,6 +383,12 @@
     },
     "Don't have an account?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie haben noch kein Konto?"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -259,6 +399,12 @@
     },
     "Ensure that the selected phone number includes the country code (e.g., +237)." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vergewissern Sie sich, dass die gewählte Rufnummer die Landesvorwahl enthält (z. B. +49)."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -269,6 +415,12 @@
     },
     "Enter code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code eingeben"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -279,6 +431,12 @@
     },
     "Enter code sent by SMS" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Per SMS gesendeten Code eingeben"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -289,6 +447,12 @@
     },
     "Enter your phone number and new passwords" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geben Sie Ihre Telefonnummer und Ihre neuen Passwörter ein"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -299,6 +463,12 @@
     },
     "Error" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -309,6 +479,12 @@
     },
     "Finish!" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -319,6 +495,12 @@
     },
     "Forgot password?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort vergessen?"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -329,6 +511,12 @@
     },
     "From " : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Von"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -339,6 +527,12 @@
     },
     "From: %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "von: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -350,6 +544,12 @@
     "Gateway Clients" : {
       "comment" : "Noun",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway-Clients"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -360,6 +560,12 @@
     },
     "Get code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code erhalten"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -370,6 +576,12 @@
     },
     "Get started!" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los geht's!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -380,6 +592,12 @@
     },
     "I accept the" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ich akzeptiere die"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -390,6 +608,12 @@
     },
     "If you don't have an account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie noch kein Konto haben"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -400,6 +624,12 @@
     },
     "If you forgot your password" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie Ihr Passwort vergessen haben"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -410,6 +640,12 @@
     },
     "in %lld seconds" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "in %lld Sekunden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -421,6 +657,12 @@
     "Introducing Vaults" : {
       "comment" : "Vaults is a noun",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einführung von Vaults"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -431,6 +673,12 @@
     },
     "Learn how it works" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erfahren Sie, wie es funktioniert"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -441,6 +689,12 @@
     },
     "Let's get you started" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So fangen Sie an"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -452,6 +706,12 @@
     "Log in" : {
       "comment" : "As a verb (eg As an action)",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einloggen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -463,6 +723,12 @@
     "Log out" : {
       "comment" : "As a verb (eg As an action)",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abmelden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -474,6 +740,12 @@
     "Login" : {
       "comment" : "Noun (eg As a page title)",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmeldung"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -484,6 +756,12 @@
     },
     "Make default" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard machen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -494,6 +772,12 @@
     },
     "Message with phone number" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nachricht mit Telefonnummer"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -504,6 +788,12 @@
     },
     "Messages are encrypted meaning the messages will be scrambled - don't worry that's intended" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Nachrichten sind verschlüsselt, d.h. die Nachrichten werden verschlüsselt - keine Sorge, das ist beabsichtigt."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -514,6 +804,12 @@
     },
     "Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nachrichten werden mit Ihrer Standard-SMS-Anwendung geteilt, die Sie zum Versenden von SMS-Nachrichten von Ihrem Gerät aus verwenden."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -524,6 +820,12 @@
     },
     "No messages sent" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Nachrichten gesendet"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -534,6 +836,12 @@
     },
     "No platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Plattformen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -544,6 +852,12 @@
     },
     "No recent messages" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine neuen Nachrichten"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -554,6 +868,12 @@
     },
     "No Vault account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Vault-Konto"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -564,6 +884,12 @@
     },
     "OTP Code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OTP-Code"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -574,6 +900,12 @@
     },
     "Password" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -590,6 +922,12 @@
     },
     "Passwords don't match" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwörter stimmen nicht überein"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -600,6 +938,12 @@
     },
     "Phone Number" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rufnummer"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -610,6 +954,12 @@
     },
     "Please create one to save your platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte erstellen Sie eine, um Ihre Plattformen zu speichern"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -621,6 +971,12 @@
     "Post" : {
       "comment" : "Verb",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beitrag"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -638,10 +994,12 @@
             "value" : "9060"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "publisher_port_production" : {
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "shouldTranslate" : false
     },
     "publisher_url_debug" : {
       "extractionState" : "manual",
@@ -652,7 +1010,8 @@
             "value" : "staging.smswithoutborders.com"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "publisher_url_production" : {
       "extractionState" : "manual",
@@ -663,10 +1022,17 @@
             "value" : "smswithoutbordres.com"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "Re-enter password" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort erneut eingeben"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -677,6 +1043,12 @@
     },
     "Read our privacy policy" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen Sie unsere Datenschutzrichtlinie"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -687,6 +1059,12 @@
     },
     "Recents" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelles"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -697,6 +1075,12 @@
     },
     "RelaySMS Vaults keep secure access to your online accounts while you are offline" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RelaySMS Vaults bieten sicheren Zugang zu Ihren Online-Konten, während Sie offline sind"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -707,6 +1091,12 @@
     },
     "Resend code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code erneut senden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -717,6 +1107,12 @@
     },
     "Revoke" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widerrufen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -727,6 +1123,12 @@
     },
     "Revoke Platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plattformen widerrufen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -737,6 +1139,12 @@
     },
     "Revoke stored platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gespeicherte Plattformen widerrufen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -747,6 +1155,12 @@
     },
     "Revoking removes the ability to send messages from this account. You can store the acocunt again at anytime." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durch den Widerruf wird die Möglichkeit zum Senden von Nachrichten von diesem Konto entfernt. Sie können das Konto jederzeit wieder speichern."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -757,6 +1171,12 @@
     },
     "Save Accounts to Vault" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten in Vault speichern"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -767,6 +1187,12 @@
     },
     "Save platforms" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plattformen speichern"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -777,6 +1203,12 @@
     },
     "Security" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sicherheit"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -787,6 +1219,12 @@
     },
     "Select a contact to send a message" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie einen Kontakt aus, um eine Nachricht zu senden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -798,6 +1236,12 @@
     "Select a platform to save it for offline use" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie eine Plattform, um sie für die Offline-Nutzung zu speichern"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -808,6 +1252,12 @@
     },
     "Select a platform to send an example message - you can send a message to yourself" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie eine Plattform, um eine Beispielnachricht zu senden - Sie können eine Nachricht an sich selbst senden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -818,6 +1268,12 @@
     },
     "Selected Gateway Client" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausgewählter Gateway-Client"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -828,6 +1284,12 @@
     },
     "Send" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senden Sie"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -838,6 +1300,12 @@
     },
     "Send new message" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Nachricht senden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -848,6 +1316,12 @@
     },
     "Send your first messages" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senden Sie Ihre ersten Nachrichten"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -858,6 +1332,12 @@
     },
     "Set as default gateway client?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als Standard-Gateway-Client festlegen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -868,6 +1348,12 @@
     },
     "Settings" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -878,6 +1364,12 @@
     },
     "Sign in to continue with existing account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmelden, um mit bestehendem Konto fortzufahren"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -888,6 +1380,12 @@
     },
     "skip" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "überspringen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -898,6 +1396,12 @@
     },
     "Subject " : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thema"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -908,6 +1412,12 @@
     },
     "Submit" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einreichen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -918,6 +1428,12 @@
     },
     "terms and conditions" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bedingungen und Konditionen"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -928,6 +1444,12 @@
     },
     "The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault unterstützt das Speichern für mehrere Online-Plattformen. Klicken Sie auf ‘Konten in Vault speichern’, um die Liste zu sehen."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -938,6 +1460,12 @@
     },
     "To " : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -948,6 +1476,12 @@
     },
     "Try Example" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versuch Beispiel"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -958,6 +1492,12 @@
     },
     "Turn this on to publish the message using your phone number and not your DeviceID.\n\nThis can help reduce the size of the SMS message" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren Sie diese Option, um die Nachricht unter Verwendung Ihrer Telefonnummer und nicht Ihrer Geräte-ID zu veröffentlichen.\n\nDies kann dazu beitragen, die Größe der SMS-Nachricht zu reduzieren"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -968,6 +1508,12 @@
     },
     "Use SMS to make a post, send emails and messages with no internet connection" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzen Sie SMS, um ohne Internetverbindung zu posten, E-Mails und Nachrichten zu versenden"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -977,7 +1523,20 @@
       }
     },
     "Vault" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        }
+      }
     },
     "vault_port_debug" : {
       "extractionState" : "manual",
@@ -988,10 +1547,12 @@
             "value" : "9050"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "vault_port_production" : {
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "shouldTranslate" : false
     },
     "vault_url_debug" : {
       "extractionState" : "manual",
@@ -1002,7 +1563,8 @@
             "value" : "staging.smswithoutborders.com"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "vault_url_production" : {
       "extractionState" : "manual",
@@ -1013,10 +1575,17 @@
             "value" : "beta.smswithoutborders.com"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "Verify" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überprüfen Sie"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1027,6 +1596,12 @@
     },
     "Verify your Phone number" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überprüfen Sie Ihre Rufnummer"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1037,6 +1612,12 @@
     },
     "Welcome back" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen zurück"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1047,6 +1628,12 @@
     },
     "Welcome to RelaySMS" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen bei RelaySMS"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1057,6 +1644,12 @@
     },
     "You are ready to begin sending messages from you added platforms." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können nun Nachrichten von den hinzugefügten Plattformen aus versenden."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1067,6 +1660,12 @@
     },
     "You are ready!" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie sind bereit!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1077,6 +1676,12 @@
     },
     "You can add accounts to Vault. This accounts are accessible to you when you are offline" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können Konten in Vault hinzufügen. Diese Konten sind für Sie auch offline zugänglich."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1087,6 +1692,12 @@
     },
     "You can add platforms from the homepage once you are logged in" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können Plattformen von der Homepage aus hinzufügen, sobald Sie eingeloggt sind"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1097,6 +1708,12 @@
     },
     "You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können jederzeit ein weiteres Konto erstellen. Alle Ihre gespeicherten Tokens werden aus dem Vault gelöscht und alle Daten entfernt."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1107,6 +1724,12 @@
     },
     "You can log back in at anytime. All the messages sent would be deleted." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können sich jederzeit wieder einloggen. Alle gesendeten Nachrichten werden dann gelöscht."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -37,6 +37,7 @@
       }
     },
     "Add Accounts to Vault" : {
+      "comment" : "Title for Add Accounts View",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -85,6 +86,7 @@
       }
     },
     "Available Platforms" : {
+      "comment" : "Title showing available platforms which can be saved for offline use",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -133,6 +135,7 @@
       }
     },
     "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform." : {
+      "comment" : "Asks the user to select a platform they would like to revoke accounts from, and explains that the next screen will allow them to choose which account to revoke",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -149,6 +152,7 @@
       }
     },
     "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered" : {
+      "comment" : "Describes helpful tip about choosing a default gateway client",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -197,6 +201,7 @@
       }
     },
     "Compose for Platform" : {
+      "comment" : "Title for page showing the platform to compose a message for",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -294,6 +299,7 @@
       }
     },
     "Create a new RelaySMS Vault account or signup to your existing." : {
+      "comment" : "Prompts user to create a RelaySMS Vault account or signup to their existing one",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -606,21 +612,8 @@
         }
       }
     },
-    "If you don't have an account" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie noch kein Konto haben"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si vous n'avez pas de compte"
-          }
-        }
-      }
+    "If you don't have an account,\nPlease create one to save your platforms" : {
+      "comment" : "Explains that you need to create an account to save your platforms if you don't have an account already"
     },
     "If you forgot your password" : {
       "localizations" : {
@@ -655,7 +648,7 @@
       }
     },
     "Introducing Vaults" : {
-      "comment" : "Vaults is a noun",
+      "comment" : "Signup/Sign in Onboarding View subtitle",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -688,6 +681,7 @@
       }
     },
     "Let's get you started" : {
+      "comment" : "Signup/signin Onboarding View title\nTitle for onboarding tab view (default",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -787,6 +781,7 @@
       }
     },
     "Messages are encrypted meaning the messages will be scrambled - don't worry that's intended" : {
+      "comment" : "Explains that messages are securely encrypted and will appear scrambled, which is fine and expected",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -803,6 +798,7 @@
       }
     },
     "Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device" : {
+      "comment" : "Explains that messages are shared default SMS app",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -952,22 +948,6 @@
         }
       }
     },
-    "Please create one to save your platforms" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte erstellen Sie eine, um Ihre Plattformen zu speichern"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez en créer un pour sauvegarder vos plates-formes"
-          }
-        }
-      }
-    },
     "Post" : {
       "comment" : "Verb",
       "localizations" : {
@@ -1074,6 +1054,7 @@
       }
     },
     "RelaySMS Vaults keep secure access to your online accounts while you are offline" : {
+      "comment" : "Explains that RelaySMS Vaults have secure access to youe online accounts even while you are offline",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1122,6 +1103,7 @@
       }
     },
     "Revoke Platforms" : {
+      "comment" : "Title for page showing the platforms to revoke an account for",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1251,6 +1233,7 @@
       }
     },
     "Select a platform to send an example message - you can send a message to yourself" : {
+      "comment" : "Description asking a user to select a platform to send an example message",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1315,6 +1298,7 @@
       }
     },
     "Send your first messages" : {
+      "comment" : "Title OnboardingTryExample View",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1443,6 +1427,7 @@
       }
     },
     "The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list" : {
+      "comment" : "Explains that the Vault supports storing for multiple online platforms and you can click to save accounts to your vault",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1643,6 +1628,7 @@
       }
     },
     "You are ready to begin sending messages from you added platforms." : {
+      "comment" : "Explains that you can start sending messages from you added platforms.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1674,23 +1660,25 @@
         }
       }
     },
-    "You can add accounts to Vault. This accounts are accessible to you when you are offline" : {
+    "You can add accounts to Vault. These accounts are accessible to you when you are offline" : {
+      "comment" : "Explains that you can add accounts to Vault and the accounts are persisted while offline",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sie können Konten in Vault hinzufügen. Diese Konten sind für Sie auch offline zugänglich."
+            "value" : "Sie können Konten zu Vault hinzufügen. Diese Konten sind auch offline für Sie zugänglich."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vous pouvez ajouter des comptes dans Vault. Ces comptes sont accessibles même lorsque vous êtes hors ligne."
+            "value" : "Vous pouvez ajouter des comptes à Vault. Ces comptes sont accessibles même lorsque vous êtes hors ligne."
           }
         }
       }
     },
     "You can add platforms from the homepage once you are logged in" : {
+      "comment" : "Explains that you can add platforms from the homepage once you are logged in",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1707,6 +1695,7 @@
       }
     },
     "You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted" : {
+      "comment" : "Explains deleting your account will remoke all previous tokens and your data will be deleted but another account can be created any time",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6,6 +6,12 @@
     },
     "%@ accounts" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحسابات %@"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18,16 +24,34 @@
             "value" : "%@ cuentas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حساب‌های %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ comptes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ hesaplar"
           }
         }
       }
     },
     "Account" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحساب"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40,10 +64,22 @@
             "value" : "Cuenta"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حساب"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compte"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesap"
           }
         }
       }
@@ -51,6 +87,12 @@
     "Add Accounts to Vault" : {
       "comment" : "Title for Add Accounts View",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة الحسابات إلى Vault"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63,16 +105,34 @@
             "value" : "Añadir cuentas a Vault"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افزودن حساب‌ها به Vault"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Ajouter des comptes à la Vault"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kasaya Hesap Ekleme"
           }
         }
       }
     },
     "Already got SMS code" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حصلت بالفعل على رمز الرسائل القصيرة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -85,16 +145,34 @@
             "value" : "Ya tengo el código SMS"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کد پیامک را قبلاً دریافت کرده‌ام"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Déjà reçu le code SMS"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SMS kodunu zaten aldım"
           }
         }
       }
     },
     "Already have an account?" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل لديك حساب بالفعل؟"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -107,10 +185,22 @@
             "value" : "¿Ya tiene una cuenta?"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قبلاً حساب دارید؟"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous avez déjà un compte ?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaten bir hesabınız var mı?"
           }
         }
       }
@@ -118,6 +208,12 @@
     "Available Platforms" : {
       "comment" : "Title showing available platforms which can be saved for offline use",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المنصات المتاحة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -130,16 +226,34 @@
             "value" : "Plataformas disponibles"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پلتفرم‌های موجود"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plates-formes disponibles"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mevcut Platformlar"
           }
         }
       }
     },
     "Bcc " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخة مخفية"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -152,16 +266,34 @@
             "value" : "Cco"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رونوشت مخفی"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cci"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bcc"
           }
         }
       }
     },
     "Cc " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -174,7 +306,19 @@
             "value" : "Cc"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رونوشت"
+          }
+        },
         "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cc"
+          }
+        },
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cc"
@@ -185,6 +329,12 @@
     "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform." : {
       "comment" : "Asks the user to select a platform they would like to revoke accounts from, and explains that the next screen will allow them to choose which account to revoke",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر المنصة التي ترغب في إلغاء الحسابات منها. ستتيح لك الشاشة التالية اختيار الحساب الذي تريد إلغاءه للمنصة.\n"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -197,10 +347,22 @@
             "value" : "Elija la plataforma de la que desea revocar cuentas. La siguiente pantalla le permitirá elegir qué cuenta revocar para la plataforma."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پلتفرمی را که می‌خواهید حساب‌ها را از آن لغو کنید انتخاب کنید. صفحه بعدی به شما اجازه می‌دهد حسابی را که می‌خواهید برای پلتفرم لغو کنید انتخاب نمایید."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Choisissez la plateforme dont vous souhaitez révoquer les comptes. L'écran suivant vous permet de choisir le compte à révoquer pour la plateforme."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesapları iptal etmek istediğiniz platformu seçin. Sonraki ekran, platform için hangi hesabın iptal edileceğini seçmenize izin verecektir."
           }
         }
       }
@@ -208,6 +370,12 @@
     "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered" : {
       "comment" : "Describes helpful tip about choosing a default gateway client",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختيار Gateway Client في نفس الموقع الجغرافي الخاص بك يساعد على تحسين موثوقية توصيل رسائلك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -220,16 +388,34 @@
             "value" : "Elegir un Gateway Client en la misma ubicación geográfica que tú ayuda a mejorar la fiabilidad de la entrega de tus mensajes."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتخاب Gateway Client در همان موقعیت جغرافیایی شما به بهبود اطمینان تحویل پیام‌های شما کمک می‌کند"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le choix d'un client Gateway situé dans la même zone géographique que vous permet d'améliorer la fiabilité de l'acheminement de vos messages."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sizinle aynı Coğrafi konumda bulunan bir Ağ Geçidi istemcisi seçmek, mesajlarınızın teslimatının güvenilirliğini artırmaya yardımcı olur"
           }
         }
       }
     },
     "Come back anytime" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عد في أي وقت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -242,16 +428,34 @@
             "value" : "Vuelve cuando quieras"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هر زمان که خواستید برگردید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Revenez à tout moment"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İstediğin zaman gel."
           }
         }
       }
     },
     "Compose email" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء بريد إلكتروني"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -264,10 +468,22 @@
             "value" : "Redactar correo electrónico"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوشتن ایمیل"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Composer un e-mail"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-posta oluşturma"
           }
         }
       }
@@ -275,6 +491,12 @@
     "Compose for Platform" : {
       "comment" : "Title for page showing the platform to compose a message for",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء للمنصة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -287,16 +509,34 @@
             "value" : "Componer para plataforma"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوشتن برای پلتفرم"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compose pour la plate-forme"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platform için Compose"
           }
         }
       }
     },
     "Compose Message" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء رسالة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -309,10 +549,22 @@
             "value" : "Redactar mensaje"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوشتن پیام"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Composer un message"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesaj Oluştur"
           }
         }
       }
@@ -320,6 +572,12 @@
     "Compose Post" : {
       "comment" : "Should \"Post\" be translated as \"Publier\"",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء منشور"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -332,16 +590,34 @@
             "value" : "Redactar mensaje"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوشتن پست"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Composer un message"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gönderi Oluştur"
           }
         }
       }
     },
     "composeBody" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء المحتوى"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -354,6 +630,12 @@
             "value" : "componerCuerpo"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوشتن متن"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -364,6 +646,12 @@
     },
     "Continue" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متابعة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -376,16 +664,34 @@
             "value" : "Continúe en"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ادامه"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuer"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Devam et"
           }
         }
       }
     },
     "Continue Deleting" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متابعة الحذف"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -398,10 +704,22 @@
             "value" : "Continuar borrando"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ادامه حذف"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Poursuivre la suppression"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silmeye Devam Et"
           }
         }
       }
@@ -409,6 +727,12 @@
     "Create a new RelaySMS Vault account or signup to your existing." : {
       "comment" : "Prompts user to create a RelaySMS Vault account or signup to their existing one",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء حساب RelaySMS Vault جديد أو تسجيل الدخول إلى حسابك الحالي."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -421,16 +745,34 @@
             "value" : "Create a new RelaySMS Vault account or signup to your existing."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یک حساب RelaySMS Vault جدید ایجاد کنید یا وارد حساب موجود خود شوید."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créez un nouveau compte RelaySMS Vault ou connectez-vous à votre compte existant."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeni bir RelaySMS Vault hesabı oluşturun veya mevcut hesabınıza kaydolun."
           }
         }
       }
     },
     "Create Account" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء حساب"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -443,16 +785,34 @@
             "value" : "Crear cuenta"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایجاد حساب"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créer un compte"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesap Oluştur"
           }
         }
       }
     },
     "Create new account or log into existing one to begin sending messages from stored online platforms" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء حساب جديد أو تسجيل الدخول إلى حساب موجود لبدء إرسال الرسائل من المنصات المخزنة عبر الإنترنت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -465,10 +825,22 @@
             "value" : "Cree una cuenta nueva o inicie sesión en una ya existente para empezar a enviar mensajes desde las plataformas en línea almacenadas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حساب جدید ایجاد کنید یا وارد حساب موجود شوید تا بتوانید از پلتفرم‌های آنلاین ذخیره شده پیام ارسال کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créez un nouveau compte ou connectez-vous à un compte existant pour commencer à envoyer des messages à partir des plateformes en ligne stockées."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saklanan çevrimiçi platformlardan mesaj göndermeye başlamak için yeni hesap oluşturun veya mevcut hesabınızda oturum açın"
           }
         }
       }
@@ -499,6 +871,12 @@
     },
     "Delete Account" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف الحساب"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -511,16 +889,34 @@
             "value" : "Eliminar cuenta"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف حساب"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Supprimer le compte"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesabı Sil"
           }
         }
       }
     },
     "Don't have an account?" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ليس لديك حساب؟"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -533,16 +929,34 @@
             "value" : "Don't have an account?"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حساب ندارید؟"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous n'avez pas de compte ?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesabınız yok mu?"
           }
         }
       }
     },
     "Ensure that the selected phone number includes the country code (e.g., +237)." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تأكد من أن رقم الهاتف المحدد يتضمن رمز البلد (مثل +237)."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -555,16 +969,34 @@
             "value" : "Asegúrese de que el número de teléfono seleccionado incluye el prefijo del país (por ejemplo, +237)."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اطمینان حاصل کنید که شماره تلفن انتخاب شده شامل کد کشور است (مثلاً +237)."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Assurez-vous que le numéro de téléphone sélectionné comprend l'indicatif du pays (par exemple, +237)."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seçilen telefon numarasının ülke kodunu içerdiğinden emin olun (örn. +90)."
           }
         }
       }
     },
     "Enter code" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل الرمز"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -577,16 +1009,34 @@
             "value" : "Introduzca el código"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کد را وارد کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisir le code"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kodu girin"
           }
         }
       }
     },
     "Enter code sent by SMS" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل الرمز المرسل عبر الرسائل القصيرة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -599,16 +1049,34 @@
             "value" : "Introduzca el código enviado por SMS"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کدی را که با پیامک ارسال شده وارد کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisir le code envoyé par SMS"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SMS ile gönderilen kodu girin"
           }
         }
       }
     },
     "Enter your phone number and new passwords" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل رقم هاتفك وكلمات المرور الجديدة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -621,16 +1089,34 @@
             "value" : "Introduce tu número de teléfono y tus nuevas contraseñas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شماره تلفن و رمزهای عبور جدید خود را وارد کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisissez votre numéro de téléphone et vos nouveaux mots de passe"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Telefon numaranızı ve yeni şifrelerinizi girin"
           }
         }
       }
     },
     "Error" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -643,16 +1129,34 @@
             "value" : "Error"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطا"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erreur"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hata"
           }
         }
       }
     },
     "Finish!" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتهى!"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -665,16 +1169,34 @@
             "value" : "¡Termina!"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پایان!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Finir !"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitir!"
           }
         }
       }
     },
     "Forgot password?" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسيت كلمة المرور؟"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -687,16 +1209,34 @@
             "value" : "¿Ha olvidado su contraseña?"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز عبور را فراموش کرده‌اید؟"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mot de passe oublié ?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şifrenizi mi unuttunuz?"
           }
         }
       }
     },
     "From " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "من"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -709,16 +1249,34 @@
             "value" : "En"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "از"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kimden"
           }
         }
       }
     },
     "From: %@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "من: %@"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -731,10 +1289,22 @@
             "value" : "De: %@ "
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "از: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De : %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kimden: %@"
           }
         }
       }
@@ -742,6 +1312,12 @@
     "Gateway Clients" : {
       "comment" : "Noun",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Clients"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -754,6 +1330,12 @@
             "value" : "Clientes de Gateway"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Clients"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -764,6 +1346,12 @@
     },
     "Get code" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحصول على الرمز"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -776,16 +1364,34 @@
             "value" : "Obtener código"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دریافت کد"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Obtenir un code"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kod al"
           }
         }
       }
     },
     "Get started!" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ابدأ الآن!"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -798,16 +1404,34 @@
             "value" : "Póngase en marcha"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شروع کنید!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Commencez !"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Başlayın!"
           }
         }
       }
     },
     "I accept the" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أقبل"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -820,10 +1444,22 @@
             "value" : "Acepto la"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "من می‌پذیرم"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "J'accepte la"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kabul ediyorum."
           }
         }
       }
@@ -831,6 +1467,12 @@
     "If you don't have an account,\nPlease create one to save your platforms" : {
       "comment" : "Explains that you need to create an account to save your platforms if you don't have an account already",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يرجى إنشاء واحد لحفظ منصاتك\n إذا لم يكن لديك حساب،\n"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -843,16 +1485,34 @@
             "value" : "Si no tiene una cuenta,\ncree una para guardar sus plataformas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگر حساب ندارید،\nلطفاً یکی ایجاد کنید تا پلتفرم‌های خود را ذخیره کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si vous n'avez pas de compte,\nVeuillez en créer un pour sauvegarder vos plateformes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğer bir hesabınız yoksa,\nLütfen platformlarınızı kaydetmek için bir tane oluşturun"
           }
         }
       }
     },
     "If you forgot your password" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إذا نسيت كلمة المرور الخاصة بك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -865,16 +1525,34 @@
             "value" : "Si ha olvidado su contraseña"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگر رمز عبور خود را فراموش کرده‌اید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si vous avez oublié votre mot de passe"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğer şifrenizi unuttuysanız"
           }
         }
       }
     },
     "in %lld seconds" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خلال %lld ثانية"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -887,10 +1565,22 @@
             "value" : "en %lld segundos"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "در %lld ثانیه"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "en %lld secondes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lld saniye içinde"
           }
         }
       }
@@ -898,6 +1588,12 @@
     "Introducing Vaults" : {
       "comment" : "Signup/Sign in Onboarding View subtitle",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نقدم Vaults"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -910,6 +1606,12 @@
             "value" : "Presentamos Vaults"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرفی Vaults"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -920,6 +1622,12 @@
     },
     "Learn how it works" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعرف على كيفية عملها"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -932,10 +1640,22 @@
             "value" : "Aprenda cómo funciona"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یاد بگیرید چگونه کار می‌کند"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En savoir plus sur son fonctionnement"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nasıl çalıştığını öğrenin"
           }
         }
       }
@@ -943,6 +1663,12 @@
     "Let's get you started" : {
       "comment" : "Signup/signin Onboarding View title\nTitle for onboarding tab view (default",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لنبدأ معك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -955,10 +1681,22 @@
             "value" : "Empecemos"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بیایید شروع کنیم"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Commençons par le commencement"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hadi başlayalım"
           }
         }
       }
@@ -966,6 +1704,12 @@
     "Log in" : {
       "comment" : "As a verb (eg As an action)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الدخول"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -978,10 +1722,22 @@
             "value" : "Conectarse"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورود"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se connecter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giriş yap"
           }
         }
       }
@@ -989,6 +1745,12 @@
     "Log out" : {
       "comment" : "As a verb (eg As an action)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الخروج"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1001,10 +1763,22 @@
             "value" : "Cerrar sesión"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خروج"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se déconnecter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oturumu kapat"
           }
         }
       }
@@ -1012,6 +1786,12 @@
     "Login" : {
       "comment" : "Noun (eg As a page title)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الدخول"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1024,16 +1804,34 @@
             "value" : "Inicio de sesión"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورود"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Connexion"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giriş"
           }
         }
       }
     },
     "Make default" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جعله افتراضي"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1046,16 +1844,34 @@
             "value" : "Por defecto"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیش‌فرض کردن"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rendre par défaut"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Varsayılan yap"
           }
         }
       }
     },
     "Message with phone number" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رسالة مع رقم الهاتف"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1068,10 +1884,22 @@
             "value" : "Mensaje con número de teléfono"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیام با شماره تلفن"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Message avec numéro de téléphone"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Telefon numarası içeren mesaj"
           }
         }
       }
@@ -1079,6 +1907,12 @@
     "Messages are encrypted meaning the messages will be scrambled - don't worry that's intended" : {
       "comment" : "Explains that messages are securely encrypted and will appear scrambled, which is fine and expected",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرسائل مشفرة مما يعني أن الرسائل ستكون مختلطة - لا تقلق هذا مقصود"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1091,10 +1925,22 @@
             "value" : "Los mensajes están encriptados, lo que significa que los mensajes serán codificados - no se preocupe que es la intención"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیام‌ها رمزگذاری می‌شوند یعنی پیام‌ها درهم خواهند شد - نگران نباشید این عمدی است"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les messages sont cryptés, ce qui signifie qu'ils seront brouillés - ne vous inquiétez pas, c'est voulu."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesajlar şifrelenir, yani mesajlar karıştırılır - endişelenmeyin bu amaçlanmıştır"
           }
         }
       }
@@ -1102,6 +1948,12 @@
     "Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device" : {
       "comment" : "Explains that messages are shared default SMS app",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتم مشاركة الرسائل مع تطبيق الرسائل القصيرة الافتراضي الذي تستخدمه لإرسال رسائل SMS من جهازك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1114,16 +1966,34 @@
             "value" : "Los mensajes se comparten con la aplicación de mensajería SMS predeterminada que utilizas para enviar mensajes SMS desde tu dispositivo."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیام‌ها با برنامه پیام‌رسانی پیش‌فرض SMS شما به اشتراک گذاشته می‌شوند که از آن برای ارسال پیام‌های SMS از دستگاه خود استفاده می‌کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les messages sont partagés avec l'application de messagerie SMS par défaut que vous utilisez pour envoyer des SMS à partir de votre appareil."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesajlar, cihazınızdan SMS mesajları göndermek için kullandığınız varsayılan SMS mesajlaşma uygulamanızla paylaşılır"
           }
         }
       }
     },
     "No messages sent" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتم إرسال رسائل"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1136,16 +2006,34 @@
             "value" : "No se envían mensajes"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هیچ پیامی ارسال نشده است"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aucun message envoyé"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gönderilen mesaj yok"
           }
         }
       }
     },
     "No platforms" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد منصات"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1158,16 +2046,34 @@
             "value" : "Sin plataformas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدون پلتفرم"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas de plates-formes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platform yok"
           }
         }
       }
     },
     "No recent messages" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد رسائل حديثة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1180,16 +2086,34 @@
             "value" : "No hay mensajes recientes"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدون پیام‌های اخیر"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas de messages récents"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son mesaj yok"
           }
         }
       }
     },
     "No Vault account" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يوجد حساب Vault"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1202,6 +2126,12 @@
             "value" : "Sin cuenta Vault"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدون حساب Vault"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1212,6 +2142,12 @@
     },
     "OTP Code" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز OTP"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1224,16 +2160,34 @@
             "value" : "Código OTP"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کد OTP"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Code OTP"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OTP Kodu"
           }
         }
       }
     },
     "Password" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كلمة المرور"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1252,16 +2206,34 @@
             "value" : "Contraseña"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز عبور"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mot de passe"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şifre"
           }
         }
       }
     },
     "Passwords don't match" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كلمات المرور غير متطابقة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1274,16 +2246,34 @@
             "value" : "Las contraseñas no coinciden"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمزهای عبور مطابقت ندارند"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les mots de passe ne correspondent pas"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parolalar eşleşmiyor"
           }
         }
       }
     },
     "Phone Number" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رقم الهاتف"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1294,6 +2284,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Número de teléfono"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شماره تلفن"
           }
         },
         "fr" : {
@@ -1307,6 +2303,12 @@
     "Post" : {
       "comment" : "Verb",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نشر"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1317,6 +2319,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "publicar"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ارسال"
           }
         },
         "fr" : {
@@ -1369,6 +2377,12 @@
     },
     "Re-enter password" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعد إدخال كلمة المرور"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1381,6 +2395,12 @@
             "value" : "Vuelva a introducir la contraseña"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز عبور را دوباره وارد کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1391,6 +2411,12 @@
     },
     "Read our privacy policy" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اقرأ سياسة الخصوصية الخاصة بنا"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1403,16 +2429,34 @@
             "value" : "Lea nuestra política de privacidad"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سیاست حفظ حریم خصوصی ما را بخوانید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lire notre politique de confidentialité"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gizlilik politikamızı okuyun"
           }
         }
       }
     },
     "Recents" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأخيرة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1425,10 +2469,22 @@
             "value" : "Recientes"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موارد اخیر"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Récents"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son Zamanlar"
           }
         }
       }
@@ -1436,6 +2492,12 @@
     "RelaySMS Vaults keep secure access to your online accounts while you are offline" : {
       "comment" : "Explains that RelaySMS Vaults have secure access to youe online accounts even while you are offline",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحتفظ RelaySMS Vaults بوصول آمن إلى حساباتك عبر الإنترنت أثناء عدم اتصالك بالإنترنت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1448,6 +2510,12 @@
             "value" : "Los bóvedas RelaySMS mantienen el acceso seguro a sus cuentas en línea mientras no está conectado."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RelaySMS Vaults دسترسی امن به حساب‌های آنلاین شما را هنگامی که آفلاین هستید حفظ می‌کند"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1458,6 +2526,12 @@
     },
     "Resend code" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة إرسال الرمز"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1470,16 +2544,34 @@
             "value" : "Reenviar código"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ارسال مجدد کد"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Renvoyer le code"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kodu yeniden gönder"
           }
         }
       }
     },
     "Revoke" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1492,10 +2584,22 @@
             "value" : "Revocar"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغو کردن"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Révoquer"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İptal"
           }
         }
       }
@@ -1503,6 +2607,12 @@
     "Revoke Platforms" : {
       "comment" : "Title for page showing the platforms to revoke an account for",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء المنصات"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1515,16 +2625,34 @@
             "value" : "Revocar plataformas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغو پلتفرم‌ها"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Révoquer les plates-formes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platformları İptal Et"
           }
         }
       }
     },
     "Revoke stored platforms" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء المنصات المخزنة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1537,16 +2665,34 @@
             "value" : "Revocar plataformas almacenadas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغو پلتفرم‌های ذخیره شده"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Révoquer les plates-formes stockées"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depolanan platformları iptal etme"
           }
         }
       }
     },
     "Revoking removes the ability to send messages from this account. You can store the acocunt again at anytime." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يؤدي الإلغاء إلى إزالة القدرة على إرسال رسائل من هذا الحساب. يمكنك تخزين الحساب مرة أخرى في أي وقت."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1559,16 +2705,34 @@
             "value" : "La revocación elimina la posibilidad de enviar mensajes desde esta cuenta. Puede almacenar la acocunt de nuevo en cualquier momento."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغو کردن توانایی ارسال پیام از این حساب را حذف می‌کند. شما می‌توانید حساب را در هر زمان دوباره ذخیره کنید."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La révocation supprime la possibilité d'envoyer des messages à partir de ce compte. Vous pouvez à tout moment réenregistrer le compte."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İptal etmek, bu hesaptan mesaj gönderme yeteneğini ortadan kaldırır. İstediğiniz zaman hesabı tekrar saklayabilirsiniz."
           }
         }
       }
     },
     "Save Accounts to Vault" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حفظ الحسابات في Vault"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1581,16 +2745,34 @@
             "value" : "Guardar cuentas en el almacén"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ذخیره حساب‌ها در Vault"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enregistrer les comptes dans Vault"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesapları Kasaya Kaydetme"
           }
         }
       }
     },
     "Save platforms" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حفظ المنصات"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1603,16 +2785,34 @@
             "value" : "Guardar plataformas"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ذخیره پلتفرم‌ها"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sauvegarder les plateformes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platformları kaydedin"
           }
         }
       }
     },
     "Security" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأمان"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1625,16 +2825,34 @@
             "value" : "Seguridad"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "امنیت"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sécurité"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenlik"
           }
         }
       }
     },
     "Select a contact to send a message" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدد جهة اتصال لإرسال رسالة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1647,10 +2865,22 @@
             "value" : "Selecciona un contacto para enviarle un mensaje"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یک مخاطب را برای ارسال پیام انتخاب کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionnez un contact pour envoyer un message"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesaj göndermek için bir kişi seçin"
           }
         }
       }
@@ -1658,6 +2888,12 @@
     "Select a platform to save it for offline use" : {
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدد منصة لحفظها للاستخدام دون اتصال بالإنترنت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1670,10 +2906,22 @@
             "value" : "Selecciona una plataforma para guardarla y utilizarla sin conexión"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یک پلتفرم را برای ذخیره جهت استفاده آفلاین انتخاب کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionner une plateforme pour l'enregistrer en vue d'une utilisation hors ligne"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çevrimdışı kullanım için kaydetmek üzere bir platform seçin"
           }
         }
       }
@@ -1681,6 +2929,12 @@
     "Select a platform to send an example message - you can send a message to yourself" : {
       "comment" : "Description asking a user to select a platform to send an example message",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدد منصة لإرسال رسالة كمثال - يمكنك إرسال رسالة لنفسك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1693,16 +2947,34 @@
             "value" : "Selecciona una plataforma para enviar un mensaje de ejemplo: puedes enviarte un mensaje a ti mismo"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یک پلتفرم را برای ارسال پیام نمونه انتخاب کنید - می‌توانید پیامی به خودتان ارسال کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionnez une plate-forme pour envoyer un exemple de message - vous pouvez vous envoyer un message à vous-même"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek bir mesaj göndermek için bir platform seçin - kendinize bir mesaj gönderebilirsiniz"
           }
         }
       }
     },
     "Selected Gateway Client" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Client المحدد"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1715,6 +2987,12 @@
             "value" : "Cliente Gateway seleccionado"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Client انتخاب شده"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1725,6 +3003,12 @@
     },
     "Send" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إرسال"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1737,16 +3021,34 @@
             "value" : "Enviar"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ارسال"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Send"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gönder"
           }
         }
       }
     },
     "Send new message" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إرسال رسالة جديدة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1759,10 +3061,22 @@
             "value" : "Enviar nuevo mensaje"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ارسال پیام جدید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Envoyer un nouveau message"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeni mesaj gönder"
           }
         }
       }
@@ -1770,6 +3084,12 @@
     "Send your first messages" : {
       "comment" : "Title OnboardingTryExample View",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أرسل رسائلك الأولى"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1782,16 +3102,34 @@
             "value" : "Envíe sus primeros mensajes"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اولین پیام‌های خود را ارسال کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Envoyez vos premiers messages"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İlk mesajlarınızı gönderin"
           }
         }
       }
     },
     "Set as default gateway client?" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعيين كـ Gateway Client افتراضي؟"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1804,6 +3142,12 @@
             "value" : "¿Establecer como cliente de puerta de enlace predeterminada?"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به عنوان Gateway Client پیش‌فرض تنظیم شود؟"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1814,6 +3158,12 @@
     },
     "Settings" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإعدادات"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1826,16 +3176,34 @@
             "value" : "Ajustes"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تنظیمات"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Paramètres"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayarlar"
           }
         }
       }
     },
     "Sign in to continue with existing account" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الدخول للمتابعة باستخدام الحساب الحالي"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1848,16 +3216,34 @@
             "value" : "Iniciar sesión para continuar con la cuenta existente"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای ادامه با حساب موجود وارد شوید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "S'identifier pour continuer avec le compte existant"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mevcut hesapla devam etmek için oturum açın"
           }
         }
       }
     },
     "skip" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تخطي"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1870,16 +3256,34 @@
             "value" : "omitir"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رد کردن"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "sauter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "atlamak"
           }
         }
       }
     },
     "Subject " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الموضوع"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1892,16 +3296,34 @@
             "value" : "Asunto"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موضوع"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sujet"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konu"
           }
         }
       }
     },
     "Submit" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إرسال"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1914,16 +3336,34 @@
             "value" : "Enviar"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ثبت"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Soumettre"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gönder"
           }
         }
       }
     },
     "terms and conditions" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الشروط والأحكام"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1936,10 +3376,22 @@
             "value" : "condiciones generales"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شرایط و ضوابط"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "conditions générales"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "şartlar ve koşullar"
           }
         }
       }
@@ -1947,6 +3399,12 @@
     "The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list" : {
       "comment" : "Explains that the Vault supports storing for multiple online platforms and you can click to save accounts to your vault",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يدعم Vault تخزين العديد من المنصات عبر الإنترنت. انقر على حفظ الحسابات في Vault لرؤية القائمة"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1959,6 +3417,12 @@
             "value" : "La Bóveda admite el almacenamiento para múltiples plataformas en línea. Haga clic en Guardar cuentas en el almacén para ver la lista."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault از ذخیره‌سازی برای چندین پلتفرم آنلاین پشتیبانی می‌کند. برای مشاهده لیست روی ذخیره حساب‌ها در Vault کلیک کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1969,6 +3433,12 @@
     },
     "To " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلى"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1981,16 +3451,34 @@
             "value" : "A"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pour"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "için"
           }
         }
       }
     },
     "Try Example" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجربة المثال"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2003,16 +3491,34 @@
             "value" : "Ejemplo de prueba"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "امتحان نمونه"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Essayer l'exemple"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek Deneyin"
           }
         }
       }
     },
     "Turn this on to publish the message using your phone number and not your DeviceID.\n\nThis can help reduce the size of the SMS message" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قم بتشغيل هذا لنشر الرسالة باستخدام رقم هاتفك وليس معرف جهازك. \nهذا يمكن أن يساعد في تقليل حجم رسالة SMS"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2025,16 +3531,34 @@
             "value" : "Active esta opción para publicar el mensaje utilizando su número de teléfono y no su DeviceID.\n\nEsto puede ayudar a reducir el tamaño del mensaje SMS"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این را روشن کنید تا پیام با استفاده از شماره تلفن شما و نه با DeviceID منتشر شود.\nاین می‌تواند به کاهش اندازه پیام SMS کمک کند"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activez cette option pour publier le message en utilisant votre numéro de téléphone et non votre DeviceID.\n\nCela permet de réduire la taille du message SMS."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesajı DeviceID'nizi değil telefon numaranızı kullanarak yayınlamak için bunu açın.\n\nBu, SMS mesajının boyutunu azaltmaya yardımcı olabilir"
           }
         }
       }
     },
     "Use SMS to make a post, send emails and messages with no internet connection" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدم الرسائل القصيرة لإنشاء منشور وإرسال رسائل البريد الإلكتروني والرسائل بدون اتصال بالإنترنت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2047,16 +3571,34 @@
             "value" : "Utiliza SMS para hacer un envío postal, enviar correos electrónicos y mensajes sin conexión a Internet"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "از پیامک برای ایجاد پست، ارسال ایمیل و پیام بدون اتصال به اینترنت استفاده کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Utiliser les SMS pour envoyer des courriers, des courriels et des messages sans connexion à Internet."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İnternet bağlantısı olmadan gönderi yapmak, e-posta ve mesaj göndermek için SMS kullanın"
           }
         }
       }
     },
     "Vault" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2064,6 +3606,12 @@
           }
         },
         "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
+        "fa" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vault"
@@ -2119,6 +3667,12 @@
     },
     "Verify" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحقق"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2131,16 +3685,34 @@
             "value" : "Verifique"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تأیید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vérifier"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doğrulama"
           }
         }
       }
     },
     "Verify your Phone number" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحقق من رقم هاتفك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2153,16 +3725,34 @@
             "value" : "Verifique su número de teléfono"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شماره تلفن خود را تأیید کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vérifiez votre numéro de téléphone"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Telefon numaranızı doğrulayın"
           }
         }
       }
     },
     "Welcome back" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مرحباً بعودتك"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2175,16 +3765,34 @@
             "value" : "Bienvenido de nuevo"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خوش آمدید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bienvenue à nouveau"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekrar hoş geldiniz"
           }
         }
       }
     },
     "Welcome to RelaySMS" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مرحباً بك في RelaySMS"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2197,10 +3805,22 @@
             "value" : "Bienvenido a RelaySMS"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به RelaySMS خوش آمدید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bienvenue à RelaySMS"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RelaySMS'e Hoş Geldiniz"
           }
         }
       }
@@ -2208,6 +3828,12 @@
     "You are ready to begin sending messages from you added platforms." : {
       "comment" : "Explains that you can start sending messages from you added platforms.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أنت جاهز لبدء إرسال الرسائل من المنصات التي أضفتها."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2220,16 +3846,34 @@
             "value" : "Ya está listo para empezar a enviar mensajes desde sus plataformas añadidas."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شما آماده شروع ارسال پیام از پلتفرم‌های اضافه شده خود هستید."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous êtes prêt à envoyer des messages à partir des plateformes que vous avez ajoutées."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eklediğiniz platformlardan mesaj göndermeye başlamaya hazırsınız."
           }
         }
       }
     },
     "You are ready!" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أنت جاهز!"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2242,10 +3886,22 @@
             "value" : "¡Estás listo!"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شما آماده هستید!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous êtes prêts !"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sen hazırsın!"
           }
         }
       }
@@ -2253,6 +3909,12 @@
     "You can add accounts to Vault. These accounts are accessible to you when you are offline" : {
       "comment" : "Explains that you can add accounts to Vault and the accounts are persisted while offline",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك إضافة حسابات إلى Vault. يمكنك الوصول إلى هذه الحسابات عندما تكون غير متصل بالإنترنت"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2263,6 +3925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Puedes añadir cuentas a Vault. Podrá acceder a estas cuentas cuando esté desconectado"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "می‌توانید حساب‌ها را به Vault اضافه کنید. این حساب‌ها هنگامی که آفلاین هستید برای شما قابل دسترسی هستند"
           }
         },
         "fr" : {
@@ -2276,6 +3944,12 @@
     "You can add platforms from the homepage once you are logged in" : {
       "comment" : "Explains that you can add platforms from the homepage once you are logged in",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك إضافة منصات من الصفحة الرئيسية بمجرد تسجيل الدخول"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2288,10 +3962,22 @@
             "value" : "Puede añadir plataformas desde la página de inicio una vez que haya iniciado sesión"
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پس از ورود می‌توانید از صفحه اصلی پلتفرم‌ها را اضافه کنید"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez ajouter des plateformes à partir de la page d'accueil une fois que vous êtes connecté."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giriş yaptıktan sonra ana sayfadan platform ekleyebilirsiniz"
           }
         }
       }
@@ -2299,6 +3985,12 @@
     "You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted" : {
       "comment" : "Explains deleting your account will remoke all previous tokens and your data will be deleted but another account can be created any time",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك إنشاء حساب آخر في أي وقت. سيتم إلغاء جميع الرموز المخزنة من Vault وحذف جميع البيانات"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2311,16 +4003,34 @@
             "value" : "Puedes crear otra cuenta en cualquier momento. Todos tus tokens almacenados serán revocados de la Bóveda y todos los datos borrados."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "می‌توانید هر زمان حساب دیگری ایجاد کنید. تمام توکن‌های ذخیره شده شما از Vault لغو و تمام داده‌ها حذف خواهند شد"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez créer un autre compte à tout moment. Tous vos jetons stockés seront révoqués de la chambre forte et toutes les données seront supprimées."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İstediğiniz zaman başka bir hesap oluşturabilirsiniz. Saklanan tüm belirteçleriniz Kasadan iptal edilecek ve tüm veriler silinecektir"
           }
         }
       }
     },
     "You can log back in at anytime. All the messages sent would be deleted." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك تسجيل الدخول مرة أخرى في أي وقت. سيتم حذف جميع الرسائل المرسلة."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2333,10 +4043,22 @@
             "value" : "Puedes volver a conectarte en cualquier momento. Se borrarán todos los mensajes enviados."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "می‌توانید هر زمان دوباره وارد شوید. تمام پیام‌های ارسال شده حذف خواهند شد."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez vous reconnecter à tout moment. Tous les messages envoyés seront supprimés."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İstediğiniz zaman tekrar giriş yapabilirsiniz. Gönderilen tüm mesajlar silinecektir."
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -12,6 +12,12 @@
             "value" : "%@ Konten"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ cuentas"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26,6 +32,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konto"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuenta"
           }
         },
         "fr" : {
@@ -45,6 +57,12 @@
             "value" : "Konten zu Vault hinzufügen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir cuentas a Vault"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61,6 +79,12 @@
             "value" : "SMS-Code bereits erhalten"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya tengo el código SMS"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75,6 +99,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie haben bereits ein Konto?"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Ya tiene una cuenta?"
           }
         },
         "fr" : {
@@ -94,6 +124,12 @@
             "value" : "Verfügbare Plattformen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plataformas disponibles"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -110,6 +146,12 @@
             "value" : "Bcc"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cco"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -121,6 +163,12 @@
     "Cc " : {
       "localizations" : {
         "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cc"
+          }
+        },
+        "es-US" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cc"
@@ -143,6 +191,12 @@
             "value" : "Wählen Sie die Plattform aus, für die Sie Konten sperren möchten. Auf dem nächsten Bildschirm können Sie auswählen, welches Konto für die Plattform widerrufen werden soll."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elija la plataforma de la que desea revocar cuentas. La siguiente pantalla le permitirá elegir qué cuenta revocar para la plataforma."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -158,6 +212,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir un Gateway Client en la misma ubicación geográfica que tú ayuda a mejorar la fiabilidad de la entrega de tus mensajes."
           }
         },
         "fr" : {
@@ -176,6 +236,12 @@
             "value" : "Jederzeit wiederkommen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuelve cuando quieras"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -190,6 +256,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "E-Mail verfassen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redactar correo electrónico"
           }
         },
         "fr" : {
@@ -209,6 +281,12 @@
             "value" : "Compose für Plattform"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Componer para plataforma"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -223,6 +301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nachricht verfassen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redactar mensaje"
           }
         },
         "fr" : {
@@ -242,6 +326,12 @@
             "value" : "Beitrag verfassen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redactar mensaje"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -256,6 +346,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "composeBody"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "componerCuerpo"
           }
         },
         "fr" : {
@@ -274,6 +370,12 @@
             "value" : "Weiter"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continúe en"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -288,6 +390,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Löschung fortsetzen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar borrando"
           }
         },
         "fr" : {
@@ -307,6 +415,12 @@
             "value" : "Erstellen Sie ein neues RelaySMS Vault-Konto oder melden Sie sich bei Ihrem bestehenden Konto an."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a new RelaySMS Vault account or signup to your existing."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -323,6 +437,12 @@
             "value" : "Konto erstellen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear cuenta"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -337,6 +457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erstellen Sie ein neues Konto oder melden Sie sich bei einem bestehenden Konto an, um Nachrichten von gespeicherten Online-Plattformen zu versenden"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cree una cuenta nueva o inicie sesión en una ya existente para empezar a enviar mensajes desde las plataformas en línea almacenadas"
           }
         },
         "fr" : {
@@ -379,6 +505,12 @@
             "value" : "Konto löschen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar cuenta"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -393,6 +525,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie haben noch kein Konto?"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't have an account?"
           }
         },
         "fr" : {
@@ -411,6 +549,12 @@
             "value" : "Vergewissern Sie sich, dass die gewählte Rufnummer die Landesvorwahl enthält (z. B. +49)."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asegúrese de que el número de teléfono seleccionado incluye el prefijo del país (por ejemplo, +237)."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -425,6 +569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Code eingeben"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduzca el código"
           }
         },
         "fr" : {
@@ -443,6 +593,12 @@
             "value" : "Per SMS gesendeten Code eingeben"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduzca el código enviado por SMS"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -457,6 +613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geben Sie Ihre Telefonnummer und Ihre neuen Passwörter ein"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce tu número de teléfono y tus nuevas contraseñas"
           }
         },
         "fr" : {
@@ -475,6 +637,12 @@
             "value" : "Fehler"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -489,6 +657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fertig!"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Termina!"
           }
         },
         "fr" : {
@@ -507,6 +681,12 @@
             "value" : "Passwort vergessen?"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Ha olvidado su contraseña?"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -523,6 +703,12 @@
             "value" : "Von"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -537,6 +723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "von: %@"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De: %@ "
           }
         },
         "fr" : {
@@ -556,6 +748,12 @@
             "value" : "Gateway-Clients"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clientes de Gateway"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -570,6 +768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Code erhalten"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener código"
           }
         },
         "fr" : {
@@ -588,6 +792,12 @@
             "value" : "Los geht's!"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Póngase en marcha"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -604,6 +814,12 @@
             "value" : "Ich akzeptiere die"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acepto la"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -613,7 +829,27 @@
       }
     },
     "If you don't have an account,\nPlease create one to save your platforms" : {
-      "comment" : "Explains that you need to create an account to save your platforms if you don't have an account already"
+      "comment" : "Explains that you need to create an account to save your platforms if you don't have an account already",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie noch kein Konto haben,\nBitte erstellen Sie eines, um Ihre Plattformen zu speichern"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si no tiene una cuenta,\ncree una para guardar sus plataformas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si vous n'avez pas de compte,\nVeuillez en créer un pour sauvegarder vos plateformes"
+          }
+        }
+      }
     },
     "If you forgot your password" : {
       "localizations" : {
@@ -621,6 +857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wenn Sie Ihr Passwort vergessen haben"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si ha olvidado su contraseña"
           }
         },
         "fr" : {
@@ -637,6 +879,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "in %lld Sekunden"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en %lld segundos"
           }
         },
         "fr" : {
@@ -656,6 +904,12 @@
             "value" : "Einführung von Vaults"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presentamos Vaults"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -670,6 +924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erfahren Sie, wie es funktioniert"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprenda cómo funciona"
           }
         },
         "fr" : {
@@ -689,6 +949,12 @@
             "value" : "So fangen Sie an"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empecemos"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -704,6 +970,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einloggen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectarse"
           }
         },
         "fr" : {
@@ -723,6 +995,12 @@
             "value" : "Abmelden"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar sesión"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -738,6 +1016,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anmeldung"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio de sesión"
           }
         },
         "fr" : {
@@ -756,6 +1040,12 @@
             "value" : "Standard machen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por defecto"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -770,6 +1060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nachricht mit Telefonnummer"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje con número de teléfono"
           }
         },
         "fr" : {
@@ -789,6 +1085,12 @@
             "value" : "Die Nachrichten sind verschlüsselt, d.h. die Nachrichten werden verschlüsselt - keine Sorge, das ist beabsichtigt."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los mensajes están encriptados, lo que significa que los mensajes serán codificados - no se preocupe que es la intención"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -804,6 +1106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nachrichten werden mit Ihrer Standard-SMS-Anwendung geteilt, die Sie zum Versenden von SMS-Nachrichten von Ihrem Gerät aus verwenden."
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los mensajes se comparten con la aplicación de mensajería SMS predeterminada que utilizas para enviar mensajes SMS desde tu dispositivo."
           }
         },
         "fr" : {
@@ -822,6 +1130,12 @@
             "value" : "Keine Nachrichten gesendet"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se envían mensajes"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -836,6 +1150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Keine Plattformen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin plataformas"
           }
         },
         "fr" : {
@@ -854,6 +1174,12 @@
             "value" : "Keine neuen Nachrichten"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay mensajes recientes"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -870,6 +1196,12 @@
             "value" : "Kein Vault-Konto"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin cuenta Vault"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -884,6 +1216,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OTP-Code"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código OTP"
           }
         },
         "fr" : {
@@ -908,6 +1246,12 @@
             "value" : "Password"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraseña"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -922,6 +1266,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Passwörter stimmen nicht überein"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las contraseñas no coinciden"
           }
         },
         "fr" : {
@@ -940,6 +1290,12 @@
             "value" : "Rufnummer"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número de teléfono"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -955,6 +1311,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beitrag"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "publicar"
           }
         },
         "fr" : {
@@ -1013,6 +1375,12 @@
             "value" : "Passwort erneut eingeben"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuelva a introducir la contraseña"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1029,6 +1397,12 @@
             "value" : "Lesen Sie unsere Datenschutzrichtlinie"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lea nuestra política de privacidad"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1043,6 +1417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktuelles"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recientes"
           }
         },
         "fr" : {
@@ -1062,6 +1442,12 @@
             "value" : "RelaySMS Vaults bieten sicheren Zugang zu Ihren Online-Konten, während Sie offline sind"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los bóvedas RelaySMS mantienen el acceso seguro a sus cuentas en línea mientras no está conectado."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1078,6 +1464,12 @@
             "value" : "Code erneut senden"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reenviar código"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1092,6 +1484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Widerrufen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revocar"
           }
         },
         "fr" : {
@@ -1111,6 +1509,12 @@
             "value" : "Plattformen widerrufen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revocar plataformas"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1125,6 +1529,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gespeicherte Plattformen widerrufen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revocar plataformas almacenadas"
           }
         },
         "fr" : {
@@ -1143,6 +1553,12 @@
             "value" : "Durch den Widerruf wird die Möglichkeit zum Senden von Nachrichten von diesem Konto entfernt. Sie können das Konto jederzeit wieder speichern."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La revocación elimina la posibilidad de enviar mensajes desde esta cuenta. Puede almacenar la acocunt de nuevo en cualquier momento."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1157,6 +1573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konten in Vault speichern"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar cuentas en el almacén"
           }
         },
         "fr" : {
@@ -1175,6 +1597,12 @@
             "value" : "Plattformen speichern"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar plataformas"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1191,6 +1619,12 @@
             "value" : "Sicherheit"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguridad"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1205,6 +1639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wählen Sie einen Kontakt aus, um eine Nachricht zu senden"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona un contacto para enviarle un mensaje"
           }
         },
         "fr" : {
@@ -1224,6 +1664,12 @@
             "value" : "Wählen Sie eine Plattform, um sie für die Offline-Nutzung zu speichern"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona una plataforma para guardarla y utilizarla sin conexión"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1239,6 +1685,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wählen Sie eine Plattform, um eine Beispielnachricht zu senden - Sie können eine Nachricht an sich selbst senden"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona una plataforma para enviar un mensaje de ejemplo: puedes enviarte un mensaje a ti mismo"
           }
         },
         "fr" : {
@@ -1257,6 +1709,12 @@
             "value" : "Ausgewählter Gateway-Client"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliente Gateway seleccionado"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1273,6 +1731,12 @@
             "value" : "Senden Sie"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1287,6 +1751,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neue Nachricht senden"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar nuevo mensaje"
           }
         },
         "fr" : {
@@ -1306,6 +1776,12 @@
             "value" : "Senden Sie Ihre ersten Nachrichten"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envíe sus primeros mensajes"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1320,6 +1796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als Standard-Gateway-Client festlegen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Establecer como cliente de puerta de enlace predeterminada?"
           }
         },
         "fr" : {
@@ -1338,6 +1820,12 @@
             "value" : "Einstellungen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1352,6 +1840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anmelden, um mit bestehendem Konto fortzufahren"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión para continuar con la cuenta existente"
           }
         },
         "fr" : {
@@ -1370,6 +1864,12 @@
             "value" : "überspringen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "omitir"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1384,6 +1884,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thema"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asunto"
           }
         },
         "fr" : {
@@ -1402,6 +1908,12 @@
             "value" : "Einreichen"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1416,6 +1928,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bedingungen und Konditionen"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "condiciones generales"
           }
         },
         "fr" : {
@@ -1435,6 +1953,12 @@
             "value" : "Vault unterstützt das Speichern für mehrere Online-Plattformen. Klicken Sie auf ‘Konten in Vault speichern’, um die Liste zu sehen."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La Bóveda admite el almacenamiento para múltiples plataformas en línea. Haga clic en Guardar cuentas en el almacén para ver la lista."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1449,6 +1973,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "An"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A"
           }
         },
         "fr" : {
@@ -1467,6 +1997,12 @@
             "value" : "Versuch Beispiel"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejemplo de prueba"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1481,6 +2017,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktivieren Sie diese Option, um die Nachricht unter Verwendung Ihrer Telefonnummer und nicht Ihrer Geräte-ID zu veröffentlichen.\n\nDies kann dazu beitragen, die Größe der SMS-Nachricht zu reduzieren"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active esta opción para publicar el mensaje utilizando su número de teléfono y no su DeviceID.\n\nEsto puede ayudar a reducir el tamaño del mensaje SMS"
           }
         },
         "fr" : {
@@ -1499,6 +2041,12 @@
             "value" : "Nutzen Sie SMS, um ohne Internetverbindung zu posten, E-Mails und Nachrichten zu versenden"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliza SMS para hacer un envío postal, enviar correos electrónicos y mensajes sin conexión a Internet"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1510,6 +2058,12 @@
     "Vault" : {
       "localizations" : {
         "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
+        "es-US" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vault"
@@ -1571,6 +2125,12 @@
             "value" : "Überprüfen Sie"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifique"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1585,6 +2145,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Überprüfen Sie Ihre Rufnummer"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifique su número de teléfono"
           }
         },
         "fr" : {
@@ -1603,6 +2169,12 @@
             "value" : "Willkommen zurück"
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenido de nuevo"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1617,6 +2189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Willkommen bei RelaySMS"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenido a RelaySMS"
           }
         },
         "fr" : {
@@ -1636,6 +2214,12 @@
             "value" : "Sie können nun Nachrichten von den hinzugefügten Plattformen aus versenden."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya está listo para empezar a enviar mensajes desde sus plataformas añadidas."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1650,6 +2234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie sind bereit!"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Estás listo!"
           }
         },
         "fr" : {
@@ -1669,6 +2259,12 @@
             "value" : "Sie können Konten zu Vault hinzufügen. Diese Konten sind auch offline für Sie zugänglich."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes añadir cuentas a Vault. Podrá acceder a estas cuentas cuando esté desconectado"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1684,6 +2280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie können Plattformen von der Homepage aus hinzufügen, sobald Sie eingeloggt sind"
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puede añadir plataformas desde la página de inicio una vez que haya iniciado sesión"
           }
         },
         "fr" : {
@@ -1703,6 +2305,12 @@
             "value" : "Sie können jederzeit ein weiteres Konto erstellen. Alle Ihre gespeicherten Tokens werden aus dem Vault gelöscht und alle Daten entfernt."
           }
         },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes crear otra cuenta en cualquier momento. Todos tus tokens almacenados serán revocados de la Bóveda y todos los datos borrados."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1717,6 +2325,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sie können sich jederzeit wieder einloggen. Alle gesendeten Nachrichten werden dann gelöscht."
+          }
+        },
+        "es-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes volver a conectarte en cualquier momento. Se borrarán todos los mensajes enviados."
           }
         },
         "fr" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -5,52 +5,215 @@
 
     },
     "%@ accounts" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ comptes"
+          }
+        }
+      }
     },
     "Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte"
+          }
+        }
+      }
+    },
+    "Add Accounts to Vault" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajouter des comptes à la Vault"
+          }
+        }
+      }
     },
     "Already got SMS code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déjà reçu le code SMS"
+          }
+        }
+      }
     },
     "Already have an account?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous avez déjà un compte ?"
+          }
+        }
+      }
+    },
+    "Available Platforms" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plates-formes disponibles"
+          }
+        }
+      }
     },
     "Bcc " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cci"
+          }
+        }
+      }
     },
     "Cc " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cc"
+          }
+        }
+      }
+    },
+    "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez la plateforme dont vous souhaitez révoquer les comptes. L'écran suivant vous permet de choisir le compte à révoquer pour la plateforme."
+          }
+        }
+      }
     },
     "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le choix d'un client Gateway situé dans la même zone géographique que vous permet d'améliorer la fiabilité de l'acheminement de vos messages."
+          }
+        }
+      }
+    },
+    "Come back anytime" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenez à tout moment"
+          }
+        }
+      }
     },
     "Compose email" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Composer un e-mail"
+          }
+        }
+      }
+    },
+    "Compose for Platform" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compose pour la plate-forme"
+          }
+        }
+      }
     },
     "Compose Message" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Composer un message"
+          }
+        }
+      }
     },
     "Compose Post" : {
-
+      "comment" : "Should \"Post\" be translated as \"Publier\"",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Composer un message"
+          }
+        }
+      }
     },
     "composeBody" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "composerCorps"
+          }
+        }
+      }
     },
     "Continue" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuer"
+          }
+        }
+      }
     },
     "Continue Deleting" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poursuivre la suppression"
+          }
+        }
+      }
     },
-    "Create account" : {
-
+    "Create a new RelaySMS Vault account or signup to your existing." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créez un nouveau compte RelaySMS Vault ou connectez-vous à votre compte existant."
+          }
+        }
+      }
     },
-    "Create Acocunt" : {
-
+    "Create Account" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer un compte"
+          }
+        }
+      }
     },
     "Create new account or log into existing one to begin sending messages from stored online platforms" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créez un nouveau compte ou connectez-vous à un compte existant pour commencer à envoyer des messages à partir des plateformes en ligne stockées."
+          }
+        }
+      }
     },
     "default_app_scheme" : {
       "extractionState" : "manual",
@@ -75,88 +238,339 @@
       }
     },
     "Delete Account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le compte"
+          }
+        }
+      }
     },
     "Don't have an account?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous n'avez pas de compte ?"
+          }
+        }
+      }
+    },
+    "Ensure that the selected phone number includes the country code (e.g., +237)." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assurez-vous que le numéro de téléphone sélectionné comprend l'indicatif du pays (par exemple, +237)."
+          }
+        }
+      }
     },
     "Enter code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisir le code"
+          }
+        }
+      }
     },
     "Enter code sent by SMS" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisir le code envoyé par SMS"
+          }
+        }
+      }
     },
     "Enter your phone number and new passwords" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez votre numéro de téléphone et vos nouveaux mots de passe"
+          }
+        }
+      }
     },
     "Error" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
+          }
+        }
+      }
     },
     "Finish!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finir !"
+          }
+        }
+      }
     },
     "Forgot password?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mot de passe oublié ?"
+          }
+        }
+      }
     },
     "From " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De"
+          }
+        }
+      }
     },
     "From: %@" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De : %@"
+          }
+        }
+      }
     },
     "Gateway Clients" : {
-
+      "comment" : "Noun",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clients Gateway"
+          }
+        }
+      }
     },
     "Get code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenir un code"
+          }
+        }
+      }
     },
     "Get started!" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencez !"
+          }
+        }
+      }
     },
     "I accept the" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "J'accepte la"
+          }
+        }
+      }
     },
     "If you don't have an account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si vous n'avez pas de compte"
+          }
+        }
+      }
     },
     "If you forgot your password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si vous avez oublié votre mot de passe"
+          }
+        }
+      }
     },
     "in %lld seconds" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en %lld secondes"
+          }
+        }
+      }
+    },
+    "Introducing Vaults" : {
+      "comment" : "Vaults is a noun",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduction à Vaults"
+          }
+        }
+      }
+    },
+    "Learn how it works" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En savoir plus sur son fonctionnement"
+          }
+        }
+      }
+    },
+    "Let's get you started" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commençons par le commencement"
+          }
+        }
+      }
     },
     "Log in" : {
-
+      "comment" : "As a verb (eg As an action)",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        }
+      }
     },
     "Log out" : {
-
+      "comment" : "As a verb (eg As an action)",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se déconnecter"
+          }
+        }
+      }
     },
     "Login" : {
-
+      "comment" : "Noun (eg As a page title)",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connexion"
+          }
+        }
+      }
     },
     "Make default" : {
-
-    },
-    "Make sure phone code e.g +237 is included in the selected number" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendre par défaut"
+          }
+        }
+      }
     },
     "Message with phone number" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message avec numéro de téléphone"
+          }
+        }
+      }
+    },
+    "Messages are encrypted meaning the messages will be scrambled - don't worry that's intended" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les messages sont cryptés, ce qui signifie qu'ils seront brouillés - ne vous inquiétez pas, c'est voulu."
+          }
+        }
+      }
+    },
+    "Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les messages sont partagés avec l'application de messagerie SMS par défaut que vous utilisez pour envoyer des SMS à partir de votre appareil."
+          }
+        }
+      }
     },
     "No messages sent" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun message envoyé"
+          }
+        }
+      }
     },
     "No platforms" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas de plates-formes"
+          }
+        }
+      }
     },
     "No recent messages" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas de messages récents"
+          }
+        }
+      }
     },
     "No Vault account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun compte Vault"
+          }
+        }
+      }
     },
     "OTP Code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code OTP"
+          }
+        }
+      }
     },
     "Password" : {
       "localizations" : {
@@ -165,20 +579,55 @@
             "state" : "translated",
             "value" : "Password"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mot de passe"
+          }
         }
       }
     },
     "Passwords don't match" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les mots de passe ne correspondent pas"
+          }
+        }
+      }
     },
     "Phone Number" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numéro de téléphone"
+          }
+        }
+      }
     },
     "Please create one to save your platforms" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veuillez en créer un pour sauvegarder vos plates-formes"
+          }
+        }
+      }
     },
     "Post" : {
-
+      "comment" : "Verb",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publier"
+          }
+        }
+      }
     },
     "publisher_port_debug" : {
       "extractionState" : "manual",
@@ -217,79 +666,315 @@
       }
     },
     "Re-enter password" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ressaisir le mot de passe"
+          }
+        }
+      }
     },
     "Read our privacy policy" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lire notre politique de confidentialité"
+          }
+        }
+      }
     },
     "Recents" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récents"
+          }
+        }
+      }
+    },
+    "RelaySMS Vaults keep secure access to your online accounts while you are offline" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les Vaults de RelaySMS garantissent un accès sécurisé à vos comptes en ligne même lorsque vous êtes hors ligne."
+          }
+        }
+      }
     },
     "Resend code" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renvoyer le code"
+          }
+        }
+      }
     },
     "Revoke" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Révoquer"
+          }
+        }
+      }
+    },
+    "Revoke Platforms" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Révoquer les plates-formes"
+          }
+        }
+      }
     },
     "Revoke stored platforms" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Révoquer les plates-formes stockées"
+          }
+        }
+      }
     },
     "Revoking removes the ability to send messages from this account. You can store the acocunt again at anytime." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La révocation supprime la possibilité d'envoyer des messages à partir de ce compte. Vous pouvez à tout moment réenregistrer le compte."
+          }
+        }
+      }
     },
     "Save Accounts to Vault" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer les comptes dans Vault"
+          }
+        }
+      }
     },
     "Save platforms" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegarder les plateformes"
+          }
+        }
+      }
     },
     "Security" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sécurité"
+          }
+        }
+      }
     },
     "Select a contact to send a message" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez un contact pour envoyer un message"
+          }
+        }
+      }
     },
-    "Selected Gateway client" : {
-
+    "Select a platform to save it for offline use" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner une plateforme pour l'enregistrer en vue d'une utilisation hors ligne"
+          }
+        }
+      }
+    },
+    "Select a platform to send an example message - you can send a message to yourself" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez une plate-forme pour envoyer un exemple de message - vous pouvez vous envoyer un message à vous-même"
+          }
+        }
+      }
+    },
+    "Selected Gateway Client" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Client Gateway sélectionné"
+          }
+        }
+      }
     },
     "Send" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
+          }
+        }
+      }
     },
     "Send new message" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer un nouveau message"
+          }
+        }
+      }
+    },
+    "Send your first messages" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyez vos premiers messages"
+          }
+        }
+      }
     },
     "Set as default gateway client?" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définir comme Client Gateway par défaut"
+          }
+        }
+      }
     },
     "Settings" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres"
+          }
+        }
+      }
     },
     "Sign in to continue with existing account" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S'identifier pour continuer avec le compte existant"
+          }
+        }
+      }
     },
     "skip" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sauter"
+          }
+        }
+      }
     },
     "Subject " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sujet"
+          }
+        }
+      }
     },
     "Submit" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soumettre"
+          }
+        }
+      }
     },
     "terms and conditions" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "conditions générales"
+          }
+        }
+      }
+    },
+    "The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le Vault prend en charge le stockage pour plusieurs plateformes en ligne. Cliquez sur ‘Enregistrer les comptes dans Vault’ pour voir la liste."
+          }
+        }
+      }
     },
     "To " : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour"
+          }
+        }
+      }
     },
     "Try Example" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Essayer l'exemple"
+          }
+        }
+      }
     },
     "Turn this on to publish the message using your phone number and not your DeviceID.\n\nThis can help reduce the size of the SMS message" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activez cette option pour publier le message en utilisant votre numéro de téléphone et non votre DeviceID.\n\nCela permet de réduire la taille du message SMS."
+          }
+        }
+      }
     },
     "Use SMS to make a post, send emails and messages with no internet connection" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser les SMS pour envoyer des courriers, des courriels et des messages sans connexion à Internet."
+          }
+        }
+      }
     },
     "Vault" : {
 
@@ -331,22 +1016,104 @@
       }
     },
     "Verify" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifier"
+          }
+        }
+      }
     },
     "Verify your Phone number" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifiez votre numéro de téléphone"
+          }
+        }
+      }
     },
     "Welcome back" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue à nouveau"
+          }
+        }
+      }
     },
     "Welcome to RelaySMS" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue à RelaySMS"
+          }
+        }
+      }
+    },
+    "You are ready to begin sending messages from you added platforms." : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous êtes prêt à envoyer des messages à partir des plateformes que vous avez ajoutées."
+          }
+        }
+      }
+    },
+    "You are ready!" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous êtes prêts !"
+          }
+        }
+      }
+    },
+    "You can add accounts to Vault. This accounts are accessible to you when you are offline" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez ajouter des comptes dans Vault. Ces comptes sont accessibles même lorsque vous êtes hors ligne."
+          }
+        }
+      }
+    },
+    "You can add platforms from the homepage once you are logged in" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez ajouter des plateformes à partir de la page d'accueil une fois que vous êtes connecté."
+          }
+        }
+      }
     },
     "You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez créer un autre compte à tout moment. Tous vos jetons stockés seront révoqués de la chambre forte et toutes les données seront supprimées."
+          }
+        }
+      }
     },
     "You can log back in at anytime. All the messages sent would be deleted." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez vous reconnecter à tout moment. Tous les messages envoyés seront supprimés."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -36,6 +36,12 @@
             "value" : "%@ comptes"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akaunti %@"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74,6 +80,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compte"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akaunti"
           }
         },
         "tr" : {
@@ -117,6 +129,12 @@
             "value" : "Ajouter des comptes à la Vault"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ongeza Akaunti kwenye Vault"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -157,6 +175,12 @@
             "value" : "Déjà reçu le code SMS"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nimepata tayari msimbo wa SMS"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -195,6 +219,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous avez déjà un compte ?"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una akaunti tayari?"
           }
         },
         "tr" : {
@@ -238,6 +268,12 @@
             "value" : "Plates-formes disponibles"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Majukwaa Yaliyopo"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -278,6 +314,12 @@
             "value" : "Cci"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nakala Bubu"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -316,6 +358,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cc"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nakala"
           }
         },
         "tr" : {
@@ -359,6 +407,12 @@
             "value" : "Choisissez la plateforme dont vous souhaitez révoquer les comptes. L'écran suivant vous permet de choisir le compte à révoquer pour la plateforme."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chagua jukwaa ambalo ungependa kufuta akaunti kutoka. Skrini inayofuata itakuwezesha kuchagua akaunti gani utafuta kutoka kwenye jukwaa."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -398,6 +452,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le choix d'un client Gateway situé dans la même zone géographique que vous permet d'améliorer la fiabilité de l'acheminement de vos messages."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuchagua Gateway Client katika eneo la Kijiografia sawa na lako husaidia kuboresha uaminifu wa ujumbe wako kuwasilishwa"
           }
         },
         "tr" : {
@@ -440,6 +500,12 @@
             "value" : "Revenez à tout moment"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rudi wakati wowote"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -478,6 +544,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Composer un e-mail"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunga barua pepe"
           }
         },
         "tr" : {
@@ -521,6 +593,12 @@
             "value" : "Compose pour la plate-forme"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunga kwa Jukwaa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -559,6 +637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Composer un message"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunga Ujumbe"
           }
         },
         "tr" : {
@@ -602,6 +686,12 @@
             "value" : "Composer un message"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunga Chapisho"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -641,6 +731,12 @@
             "state" : "translated",
             "value" : "composerCorps"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tungaMwili"
+          }
         }
       }
     },
@@ -674,6 +770,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuer"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endelea"
           }
         },
         "tr" : {
@@ -714,6 +816,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Poursuivre la suppression"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endelea Kufuta"
           }
         },
         "tr" : {
@@ -757,6 +865,12 @@
             "value" : "Créez un nouveau compte RelaySMS Vault ou connectez-vous à votre compte existant."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fungua akaunti mpya ya RelaySMS Vault au ingia kwenye akaunti yako iliyopo."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -797,6 +911,12 @@
             "value" : "Créer un compte"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fungua Akaunti"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -835,6 +955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Créez un nouveau compte ou connectez-vous à un compte existant pour commencer à envoyer des messages à partir des plateformes en ligne stockées."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fungua akaunti mpya au ingia kwenye iliyopo ili kuanza kutuma ujumbe kutoka kwenye majukwaa ya mtandaoni yaliyohifadhiwa"
           }
         },
         "tr" : {
@@ -901,6 +1027,12 @@
             "value" : "Supprimer le compte"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Futa Akaunti"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -939,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous n'avez pas de compte ?"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huna akaunti?"
           }
         },
         "tr" : {
@@ -981,6 +1119,12 @@
             "value" : "Assurez-vous que le numéro de téléphone sélectionné comprend l'indicatif du pays (par exemple, +237)."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakikisha namba ya simu iliyochaguliwa inajumuisha msimbo wa nchi (k.m., +237)."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1019,6 +1163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisir le code"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingiza msimbo"
           }
         },
         "tr" : {
@@ -1061,6 +1211,12 @@
             "value" : "Saisir le code envoyé par SMS"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingiza msimbo uliotumwa kwa SMS"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1099,6 +1255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisissez votre numéro de téléphone et vos nouveaux mots de passe"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingiza namba yako ya simu na nenosiri mpya"
           }
         },
         "tr" : {
@@ -1141,6 +1303,12 @@
             "value" : "Erreur"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hitilafu"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1179,6 +1347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Finir !"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maliza!"
           }
         },
         "tr" : {
@@ -1221,6 +1395,12 @@
             "value" : "Mot de passe oublié ?"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umesahau nenosiri?"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1259,6 +1439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "De"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kutoka"
           }
         },
         "tr" : {
@@ -1301,6 +1487,12 @@
             "value" : "De : %@"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kutoka: %@"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1341,6 +1533,12 @@
             "state" : "translated",
             "value" : "Clients Gateway"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Clients"
+          }
         }
       }
     },
@@ -1374,6 +1572,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Obtenir un code"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pata msimbo"
           }
         },
         "tr" : {
@@ -1416,6 +1620,12 @@
             "value" : "Commencez !"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anza!"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1454,6 +1664,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "J'accepte la"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninakubali"
           }
         },
         "tr" : {
@@ -1497,6 +1713,12 @@
             "value" : "Si vous n'avez pas de compte,\nVeuillez en créer un pour sauvegarder vos plateformes"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikiwa huna akaunti,\nTafadhali tengeneza moja ili kuhifadhi majukwaa yako"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1535,6 +1757,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si vous avez oublié votre mot de passe"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikiwa umesahau nenosiri lako"
           }
         },
         "tr" : {
@@ -1577,6 +1805,12 @@
             "value" : "en %lld secondes"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ndani ya sekunde %lld"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1617,6 +1851,12 @@
             "state" : "translated",
             "value" : "Introduction à Vaults"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunatambulisha Vaults"
+          }
         }
       }
     },
@@ -1650,6 +1890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "En savoir plus sur son fonctionnement"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jifunze jinsi inavyofanya kazi"
           }
         },
         "tr" : {
@@ -1693,6 +1939,12 @@
             "value" : "Commençons par le commencement"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hebu tukuanzishe"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1732,6 +1984,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se connecter"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingia"
           }
         },
         "tr" : {
@@ -1775,6 +2033,12 @@
             "value" : "Se déconnecter"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toka"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1814,6 +2078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Connexion"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingia"
           }
         },
         "tr" : {
@@ -1856,6 +2126,12 @@
             "value" : "Rendre par défaut"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fanya kuwa chaguo-msingi"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1894,6 +2170,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Message avec numéro de téléphone"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ujumbe na namba ya simu"
           }
         },
         "tr" : {
@@ -1937,6 +2219,12 @@
             "value" : "Les messages sont cryptés, ce qui signifie qu'ils seront brouillés - ne vous inquiétez pas, c'est voulu."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ujumbe umesimbwa maana ujumbe utachanganywa - usijali hiyo ni nia"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1976,6 +2264,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les messages sont partagés avec l'application de messagerie SMS par défaut que vous utilisez pour envoyer des SMS à partir de votre appareil."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ujumbe unashirikiwa na programu yako ya ujumbe wa SMS chaguo-msingi ambayo unatumia kutuma ujumbe wa SMS kutoka kwenye kifaa chako"
           }
         },
         "tr" : {
@@ -2018,6 +2312,12 @@
             "value" : "Aucun message envoyé"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakuna ujumbe uliotumwa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2056,6 +2356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas de plates-formes"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakuna majukwaa"
           }
         },
         "tr" : {
@@ -2098,6 +2404,12 @@
             "value" : "Pas de messages récents"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakuna ujumbe wa hivi karibuni"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2137,6 +2449,12 @@
             "state" : "translated",
             "value" : "Aucun compte Vault"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakuna akaunti ya Vault"
+          }
         }
       }
     },
@@ -2170,6 +2488,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Code OTP"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Msimbo wa OTP"
           }
         },
         "tr" : {
@@ -2218,6 +2542,12 @@
             "value" : "Mot de passe"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenosiri"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2256,6 +2586,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les mots de passe ne correspondent pas"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenosiri hazifanani"
           }
         },
         "tr" : {
@@ -2297,6 +2633,12 @@
             "state" : "translated",
             "value" : "Numéro de téléphone"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Namba ya Simu"
+          }
         }
       }
     },
@@ -2331,6 +2673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publier"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapisha"
           }
         }
       }
@@ -2406,6 +2754,12 @@
             "state" : "translated",
             "value" : "Ressaisir le mot de passe"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingiza tena nenosiri"
+          }
         }
       }
     },
@@ -2439,6 +2793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lire notre politique de confidentialité"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soma sera yetu ya faragha"
           }
         },
         "tr" : {
@@ -2481,6 +2841,12 @@
             "value" : "Récents"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Za Hivi Karibuni"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2521,6 +2887,12 @@
             "state" : "translated",
             "value" : "Les Vaults de RelaySMS garantissent un accès sécurisé à vos comptes en ligne même lorsque vous êtes hors ligne."
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RelaySMS Vaults huhifadhi ufikiaji salama kwa akaunti zako za mtandaoni wakati uko nje ya mtandao"
+          }
         }
       }
     },
@@ -2554,6 +2926,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Renvoyer le code"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuma tena msimbo"
           }
         },
         "tr" : {
@@ -2594,6 +2972,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Révoquer"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batilisha"
           }
         },
         "tr" : {
@@ -2637,6 +3021,12 @@
             "value" : "Révoquer les plates-formes"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batilisha Majukwaa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2675,6 +3065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Révoquer les plates-formes stockées"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batilisha majukwaa yaliyohifadhiwa"
           }
         },
         "tr" : {
@@ -2717,6 +3113,12 @@
             "value" : "La révocation supprime la possibilité d'envoyer des messages à partir de ce compte. Vous pouvez à tout moment réenregistrer le compte."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kubatilisha kuondoa uwezo wa kutuma ujumbe kutoka akaunti hii. Unaweza kuhifadhi akaunti tena wakati wowote."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2755,6 +3157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enregistrer les comptes dans Vault"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hifadhi Akaunti kwenye Vault"
           }
         },
         "tr" : {
@@ -2797,6 +3205,12 @@
             "value" : "Sauvegarder les plateformes"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hifadhi majukwaa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2837,6 +3251,12 @@
             "value" : "Sécurité"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usalama"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2875,6 +3295,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionnez un contact pour envoyer un message"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chagua anwani kutuma ujumbe"
           }
         },
         "tr" : {
@@ -2918,6 +3344,12 @@
             "value" : "Sélectionner une plateforme pour l'enregistrer en vue d'une utilisation hors ligne"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chagua jukwaa kuhifadhi kwa matumizi ya nje ya mtandao"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2959,6 +3391,12 @@
             "value" : "Sélectionnez une plate-forme pour envoyer un exemple de message - vous pouvez vous envoyer un message à vous-même"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chagua jukwaa kutuma ujumbe wa mfano - unaweza kutuma ujumbe kwako mwenyewe"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2998,6 +3436,12 @@
             "state" : "translated",
             "value" : "Client Gateway sélectionné"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gateway Client Iliyochaguliwa"
+          }
         }
       }
     },
@@ -3031,6 +3475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Send"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuma"
           }
         },
         "tr" : {
@@ -3071,6 +3521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Envoyer un nouveau message"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuma ujumbe mpya"
           }
         },
         "tr" : {
@@ -3114,6 +3570,12 @@
             "value" : "Envoyez vos premiers messages"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuma ujumbe wako wa kwanza"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3153,6 +3615,12 @@
             "state" : "translated",
             "value" : "Définir comme Client Gateway par défaut"
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weka kama gateway client ya chaguo-msingi?"
+          }
         }
       }
     },
@@ -3186,6 +3654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Paramètres"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mipangilio"
           }
         },
         "tr" : {
@@ -3228,6 +3702,12 @@
             "value" : "S'identifier pour continuer avec le compte existant"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingia ili kuendelea na akaunti iliyopo"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3266,6 +3746,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "sauter"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruka"
           }
         },
         "tr" : {
@@ -3308,6 +3794,12 @@
             "value" : "Sujet"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Somo"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3346,6 +3838,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Soumettre"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wasilisha"
           }
         },
         "tr" : {
@@ -3388,6 +3886,12 @@
             "value" : "conditions générales"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "masharti na masharti"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3428,6 +3932,12 @@
             "state" : "translated",
             "value" : "Le Vault prend en charge le stockage pour plusieurs plateformes en ligne. Cliquez sur ‘Enregistrer les comptes dans Vault’ pour voir la liste."
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault inasaidia kuhifadhi kwa majukwaa mengi ya mtandaoni. Bofya Hifadhi Akaunti kwenye Vault kuona orodha"
+          }
         }
       }
     },
@@ -3461,6 +3971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pour"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kwa"
           }
         },
         "tr" : {
@@ -3503,6 +4019,12 @@
             "value" : "Essayer l'exemple"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jaribu Mfano"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3541,6 +4063,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activez cette option pour publier le message en utilisant votre numéro de téléphone et non votre DeviceID.\n\nCela permet de réduire la taille du message SMS."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Washa hii kuchapisha ujumbe kwa kutumia namba yako ya simu na sio DeviceID yako. \n\nHii inaweza kusaidia kupunguza ukubwa wa ujumbe wa SMS"
           }
         },
         "tr" : {
@@ -3583,6 +4111,12 @@
             "value" : "Utiliser les SMS pour envoyer des courriers, des courriels et des messages sans connexion à Internet."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tumia SMS kutengeneza chapisho, kutuma barua pepe na ujumbe bila muunganisho wa intaneti"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3618,6 +4152,12 @@
           }
         },
         "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
+        "sw" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vault"
@@ -3697,6 +4237,12 @@
             "value" : "Vérifier"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thibitisha"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3735,6 +4281,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vérifiez votre numéro de téléphone"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thibitisha namba yako ya Simu"
           }
         },
         "tr" : {
@@ -3777,6 +4329,12 @@
             "value" : "Bienvenue à nouveau"
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karibu tena"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3815,6 +4373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bienvenue à RelaySMS"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karibu kwenye RelaySMS"
           }
         },
         "tr" : {
@@ -3858,6 +4422,12 @@
             "value" : "Vous êtes prêt à envoyer des messages à partir des plateformes que vous avez ajoutées."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uko tayari kuanza kutuma ujumbe kutoka majukwaa uliyoongeza."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3896,6 +4466,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous êtes prêts !"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uko tayari!"
           }
         },
         "tr" : {
@@ -3938,6 +4514,12 @@
             "state" : "translated",
             "value" : "Vous pouvez ajouter des comptes à Vault. Ces comptes sont accessibles même lorsque vous êtes hors ligne."
           }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unaweza kuongeza akaunti kwenye Vault. Akaunti hizi zinapatikana kwako wakati uko nje ya mtandao"
+          }
         }
       }
     },
@@ -3972,6 +4554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez ajouter des plateformes à partir de la page d'accueil une fois que vous êtes connecté."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unaweza kuongeza majukwaa kutoka ukurasa wa mwanzo mara tu utakapoingia"
           }
         },
         "tr" : {
@@ -4015,6 +4603,12 @@
             "value" : "Vous pouvez créer un autre compte à tout moment. Tous vos jetons stockés seront révoqués de la chambre forte et toutes les données seront supprimées."
           }
         },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unaweza kuunda akaunti nyingine wakati wowote. Viashiria vyako vyote vilivyohifadhiwa vitabatilishwa kutoka Vault na data zote zitafutwa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4053,6 +4647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez vous reconnecter à tout moment. Tous les messages envoyés seront supprimés."
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unaweza kuingia tena wakati wowote. Ujumbe wote uliotumwa utafutwa."
           }
         },
         "tr" : {

--- a/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
+++ b/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		3BF3D1642C349907003A3AFB /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3BF3D1632C349907003A3AFB /* CryptoSwift */; };
 		3BF3D1652C349977003A3AFB /* gRPCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1179E2C2B6727003D5BB6 /* gRPCHandler.swift */; };
 		3BF3D1662C3499A6003A3AFB /* CSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EDE37F28D0D23000E50393 /* CSecurity.swift */; };
+		F6E4956F2D5612B6009A5010 /* LocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */; };
+		F6E495702D5612B6009A5010 /* LocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +212,7 @@
 		3BF117AD2C2F6E7B003D5BB6 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		3BF3D14E2C32D69D003A3AFB /* SignupSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupSheetView.swift; sourceTree = "<group>"; };
 		3BF3D1542C32E7E1003A3AFB /* OTPSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPSheetView.swift; sourceTree = "<group>"; };
+		F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationKeys.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -282,17 +285,18 @@
 		16F0E68128C6308600FDD12C /* SMSWithoutBorders-Production */ = {
 			isa = PBXGroup;
 			children = (
-				3B928A3A2C6692B400BA145F /* PlatformViews */,
-				3BC75BEE2C523F26004233CE /* PlatformComposeViews */,
-				3BF1177E2C290650003D5BB6 /* Proto */,
-				3B37F27A2C1DBB1D008D5BE9 /* Modules */,
+				F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */,
 				16EDE37A28CC936200E50393 /* SMSWithoutBorders-Production.entitlements */,
 				16EDE37928CBA1A300E50393 /* Info.plist */,
-				16F0E6B328C80BBC00FDD12C /* Commons */,
-				16F0E6AC28C6320F00FDD12C /* Views */,
 				16F0E68628C6308800FDD12C /* Assets.xcassets */,
-				16F0E68828C6308800FDD12C /* Preview Content */,
+				16F0E6B328C80BBC00FDD12C /* Commons */,
 				16EDE38328D2331C00E50393 /* Datastore.xcdatamodeld */,
+				3B37F27A2C1DBB1D008D5BE9 /* Modules */,
+				3BC75BEE2C523F26004233CE /* PlatformComposeViews */,
+				3B928A3A2C6692B400BA145F /* PlatformViews */,
+				16F0E68828C6308800FDD12C /* Preview Content */,
+				3BF1177E2C290650003D5BB6 /* Proto */,
+				16F0E6AC28C6320F00FDD12C /* Views */,
 			);
 			path = "SMSWithoutBorders-Production";
 			sourceTree = "<group>";
@@ -554,6 +558,9 @@
 			knownRegions = (
 				en,
 				Base,
+				fr,
+				de,
+				"es-US",
 			);
 			mainGroup = 16F0E67628C6308600FDD12C;
 			packageReferences = (
@@ -635,6 +642,7 @@
 				3B928A3C2C6692CF00BA145F /* EmailPlatformView.swift in Sources */,
 				3B7EEE5F2C5E849800611092 /* relay_publisher.pb.swift in Sources */,
 				3B7EEE602C5E849800611092 /* relay_publisher.grpc.swift in Sources */,
+				F6E4956F2D5612B6009A5010 /* LocalizationKeys.swift in Sources */,
 				1697672628E483F60021BFC5 /* OperatorHandlers.swift in Sources */,
 				3BF1179F2C2B6727003D5BB6 /* gRPCHandler.swift in Sources */,
 				3BCBA3A42C49819800736B9B /* OnboardingTryExample.swift in Sources */,
@@ -671,6 +679,7 @@
 				3B7EEE432C5BDE3B00611092 /* OnboardingTryExample.swift in Sources */,
 				3B928A3D2C6692CF00BA145F /* EmailPlatformView.swift in Sources */,
 				3B7EEE402C5BDE1E00611092 /* LoginSheetView.swift in Sources */,
+				F6E495702D5612B6009A5010 /* LocalizationKeys.swift in Sources */,
 				3B928A362C65140100BA145F /* GatewayClientsView.swift in Sources */,
 				3B7EEE3F2C5BDDF500611092 /* OnboardingIntroToVaults.swift in Sources */,
 				3BDADAE12C54DBDE00539E57 /* SMSWithoutBorders_ProductionApp.swift in Sources */,

--- a/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
+++ b/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
@@ -557,6 +557,10 @@
 				fr,
 				de,
 				"es-US",
+				tr,
+				ar,
+				sw,
+				fa,
 			);
 			mainGroup = 16F0E67628C6308600FDD12C;
 			packageReferences = (

--- a/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
+++ b/SMSWithoutBorders-Production.xcodeproj/project.pbxproj
@@ -131,8 +131,6 @@
 		3BF3D1642C349907003A3AFB /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3BF3D1632C349907003A3AFB /* CryptoSwift */; };
 		3BF3D1652C349977003A3AFB /* gRPCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1179E2C2B6727003D5BB6 /* gRPCHandler.swift */; };
 		3BF3D1662C3499A6003A3AFB /* CSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EDE37F28D0D23000E50393 /* CSecurity.swift */; };
-		F6E4956F2D5612B6009A5010 /* LocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */; };
-		F6E495702D5612B6009A5010 /* LocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -212,7 +210,6 @@
 		3BF117AD2C2F6E7B003D5BB6 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		3BF3D14E2C32D69D003A3AFB /* SignupSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupSheetView.swift; sourceTree = "<group>"; };
 		3BF3D1542C32E7E1003A3AFB /* OTPSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPSheetView.swift; sourceTree = "<group>"; };
-		F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationKeys.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -285,7 +282,6 @@
 		16F0E68128C6308600FDD12C /* SMSWithoutBorders-Production */ = {
 			isa = PBXGroup;
 			children = (
-				F6E4956E2D5612AF009A5010 /* LocalizationKeys.swift */,
 				16EDE37A28CC936200E50393 /* SMSWithoutBorders-Production.entitlements */,
 				16EDE37928CBA1A300E50393 /* Info.plist */,
 				16F0E68628C6308800FDD12C /* Assets.xcassets */,
@@ -642,7 +638,6 @@
 				3B928A3C2C6692CF00BA145F /* EmailPlatformView.swift in Sources */,
 				3B7EEE5F2C5E849800611092 /* relay_publisher.pb.swift in Sources */,
 				3B7EEE602C5E849800611092 /* relay_publisher.grpc.swift in Sources */,
-				F6E4956F2D5612B6009A5010 /* LocalizationKeys.swift in Sources */,
 				1697672628E483F60021BFC5 /* OperatorHandlers.swift in Sources */,
 				3BF1179F2C2B6727003D5BB6 /* gRPCHandler.swift in Sources */,
 				3BCBA3A42C49819800736B9B /* OnboardingTryExample.swift in Sources */,
@@ -679,7 +674,6 @@
 				3B7EEE432C5BDE3B00611092 /* OnboardingTryExample.swift in Sources */,
 				3B928A3D2C6692CF00BA145F /* EmailPlatformView.swift in Sources */,
 				3B7EEE402C5BDE1E00611092 /* LoginSheetView.swift in Sources */,
-				F6E495702D5612B6009A5010 /* LocalizationKeys.swift in Sources */,
 				3B928A362C65140100BA145F /* GatewayClientsView.swift in Sources */,
 				3B7EEE3F2C5BDDF500611092 /* OnboardingIntroToVaults.swift in Sources */,
 				3BDADAE12C54DBDE00539E57 /* SMSWithoutBorders_ProductionApp.swift in Sources */,

--- a/SMSWithoutBorders-Production/PlatformComposeViews/MessagingView.swift
+++ b/SMSWithoutBorders-Production/PlatformComposeViews/MessagingView.swift
@@ -131,7 +131,7 @@ struct MessagingView: View {
                     Text("Select a contact to send a message")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text("Make sure phone code e.g +237 is included in the selected number")
+                    Text("Ensure that the selected phone number includes the country code (e.g., +237).")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     VStack {

--- a/SMSWithoutBorders-Production/Views/Homepage/GatewayClientsView.swift
+++ b/SMSWithoutBorders-Production/Views/Homepage/GatewayClientsView.swift
@@ -54,7 +54,7 @@ struct GatewayClientsView: View {
                     ForEach(gatewayClients) { gatewayClient in
                         if gatewayClient.msisdn == defaultGatewayClientMsisdn {
                             VStack {
-                                Text("Selected Gateway client")
+                                Text("Selected Gateway Client")
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .font(.caption2)
                                     .padding(.bottom, 3)

--- a/SMSWithoutBorders-Production/Views/Homepage/GatewayClientsView.swift
+++ b/SMSWithoutBorders-Production/Views/Homepage/GatewayClientsView.swift
@@ -82,7 +82,9 @@ struct GatewayClientsView: View {
                         defaultGatewayClientMsisdn = selectedGatewayClient
                     }
                 } message: {
-                    Text("Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered")
+                    Text(String(localized: "Choosing a Gateway client in the same Geographical location as you helps improves the reliability of your messages being delivered", comment: "Describes helpful tip about choosing a default gateway client")
+                        
+                    )
                 }
             }
             .navigationTitle("Gateway Clients")

--- a/SMSWithoutBorders-Production/Views/Homepage/RecentsView.swift
+++ b/SMSWithoutBorders-Production/Views/Homepage/RecentsView.swift
@@ -224,7 +224,7 @@ struct RecentsView: View {
             Button {
                 signupSheetVisible = true
             } label: {
-                Text("Create account")
+                Text("Create Account")
                     .bold()
                     .frame(maxWidth: .infinity)
             }

--- a/SMSWithoutBorders-Production/Views/Homepage/SettingsView.swift
+++ b/SMSWithoutBorders-Production/Views/Homepage/SettingsView.swift
@@ -52,7 +52,7 @@ struct SecuritySettingsView: View {
                         }.confirmationDialog("", isPresented: $showIsDeleting) {
                             Button("Continue Deleting", role: .destructive, action: deleteAccount)
                         } message: {
-                            Text("You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted")
+                            Text(String(localized:"You can create another account anytime. All your stored tokens would be revoked from the Vault and all data deleted", comment: "Explains deleting your account will remoke all previous tokens and your data will be deleted but another account can be created any time"))
                         }
                     }
                 }

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingFinish.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingFinish.swift
@@ -13,11 +13,11 @@ struct OnboardingFinish: View {
     var body: some View {
         VStack {
             Tab(buttonView: EmptyView(),
-                title: "You are ready!",
-                subTitle: "Come back anytime",
-                description: "You are ready to begin sending messages from you added platforms.",
+                title: String(localized:"You are ready!"),
+                subTitle: String(localized: "Come back anytime"),
+                description: String(localized: "You are ready to begin sending messages from you added platforms.", comment: "Explains that you can start sending messages from you added platforms."),
                 imageName: "OnboardingAddAccountExample",
-                subDescription: "You can add platforms from the homepage once you are logged in"
+                subDescription: String(localized:"You can add platforms from the homepage once you are logged in", comment: "Explains that you can add platforms from the homepage once you are logged in")
             )
         }
         .padding()

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingIntroToVaults.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingIntroToVaults.swift
@@ -49,11 +49,11 @@ struct signupLoginOnboardingView: View {
                     }
                     
                 },
-                title:"Let's get you started",
-                subTitle: "Introducing Vaults",
-                description: "RelaySMS Vaults keep secure access to your online accounts while you are offline",
+                title:String(localized:"Let's get you started", comment: "Signup/signin Onboarding View title"),
+                subTitle: String(localized:"Introducing Vaults", comment: "Signup/Sign in Onboarding View subtitle"),
+                description: String(localized:"RelaySMS Vaults keep secure access to your online accounts while you are offline", comment: "Explains that RelaySMS Vaults have secure access to youe online accounts even while you are offline"),
                 imageName: "OnboardingVault",
-                subDescription: "Create a new RelaySMS Vault account or signup to your existing."
+                subDescription: String(localized:"Create a new RelaySMS Vault account or signup to your existing.", comment: "Prompts user to create a RelaySMS Vault account or signup to their existing one")
             )
         }
     }
@@ -63,8 +63,8 @@ struct addAccountsView: View {
     @Binding var codeVerifier: String
     @Binding var availablePlatformsPresented: Bool
     
-     var title: LocalizedStringKey = "Available Platforms"
-     var description: LocalizedStringKey = "Select a platform to save it for offline use"
+    var title: String = String(localized:"Available Platforms")
+    var description: String = String(localized:"Select a platform to save it for offline use", comment: "Asks a user to select a platform which should be saved for offline use later")
     
     @FetchRequest(sortDescriptors: []) var storedPlatforms: FetchedResults<StoredPlatformsEntity>
     
@@ -86,11 +86,11 @@ struct addAccountsView: View {
                 .controlSize(.large)
                 .padding(.bottom, 10)
                 .buttonStyle(.borderedProminent),
-                title: "Add Accounts to Vault",
-                subTitle: "Let's get you started",
-                description: "You can add accounts to Vault. This accounts are accessible to you when you are offline",
+                title: String(localized:"Add Accounts to Vault", comment: "Title for Add Accounts View"),
+                subTitle: String(localized:"Let's get you started"),
+                description: String(localized:"You can add accounts to Vault. These accounts are accessible to you when you are offline", comment: "Explains that you can add accounts to Vault and the accounts are persisted while offline"),
                 imageName: "OnboardingVaultOpen",
-                subDescription: "The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list"
+                subDescription: String(localized:"The Vault supports storing for multiple online platforms. Click Save Accounts to Vault to see the list", comment: "Explains that the Vault supports storing for multiple online platforms and you can click to save accounts to your vault")
             )
         }
         .task {

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingIntroToVaults.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingIntroToVaults.swift
@@ -21,7 +21,7 @@ struct signupLoginOnboardingView: View {
                     Button {
                         signupSheetShown = true
                     } label: {
-                        Text("Create Acocunt")
+                        Text("Create Account")
                             .bold()
                             .frame(maxWidth: .infinity)
                     }
@@ -35,7 +35,7 @@ struct signupLoginOnboardingView: View {
                     Button {
                         loginSheetShown = true
                     } label: {
-                        Text("Login")
+                        Text("Log in")
                             .bold()
                             .frame(maxWidth: .infinity)
                     }
@@ -63,8 +63,8 @@ struct addAccountsView: View {
     @Binding var codeVerifier: String
     @Binding var availablePlatformsPresented: Bool
     
-    @State var title: String = "Available platforms"
-    @State var description = "Select a platform to save it for offline use"
+     var title: LocalizedStringKey = "Available Platforms"
+     var description: LocalizedStringKey = "Select a platform to save it for offline use"
     
     @FetchRequest(sortDescriptors: []) var storedPlatforms: FetchedResults<StoredPlatformsEntity>
     

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTabAdapterView.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTabAdapterView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct Tab<ButtonView: View>: View {
     let buttonView: ButtonView
-    @State var title: String = "Let's get you started"
-    @State var subTitle: String
-    @State var description: String
+    @State var title: LocalizedStringKey = "Let's get you started"
+    @State var subTitle: LocalizedStringKey
+    @State var description: LocalizedStringKey
     @State var imageName: String
-    @State var subDescription: String
+    @State var subDescription: LocalizedStringKey
     
 
     var body: some View {

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTabAdapterView.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTabAdapterView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct Tab<ButtonView: View>: View {
     let buttonView: ButtonView
-    @State var title: LocalizedStringKey = "Let's get you started"
-    @State var subTitle: LocalizedStringKey
-    @State var description: LocalizedStringKey
+    @State var title: String = String(localized:"Let's get you started", comment: "Title for onboarding tab view (default")
+    @State var subTitle: String
+    @State var description: String
     @State var imageName: String
-    @State var subDescription: LocalizedStringKey
+    @State var subDescription: String
     
 
     var body: some View {

--- a/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTryExample.swift
+++ b/SMSWithoutBorders-Production/Views/Onboarding/OnboardingTryExample.swift
@@ -36,11 +36,11 @@ struct OnboardingTryExample: View {
                                 }.hidden()
                         )
                     },
-                    title:"Send your first messages",
-                    subTitle: "Learn how it works",
-                    description: "Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device",
+                    title:String(localized:"Send your first messages", comment: "Title OnboardingTryExample View"),
+                    subTitle: String(localized:"Learn how it works"),
+                    description: String(localized:"Messages are shared with your default SMS messaging app which you use to send out SMS messages from your device", comment: "Explains that messages are shared default SMS app"),
                     imageName: "OnboardingTryExample",
-                    subDescription: "Messages are encrypted meaning the messages will be scrambled - don't worry that's intended"
+                    subDescription: String(localized:"Messages are encrypted meaning the messages will be scrambled - don't worry that's intended", comment: "Explains that messages are securely encrypted and will appear scrambled, which is fine and expected")
                 )
             }
             

--- a/SMSWithoutBorders-Production/Views/SheetViews/AvailablePlatformsSheetsView.swift
+++ b/SMSWithoutBorders-Production/Views/SheetViews/AvailablePlatformsSheetsView.swift
@@ -12,10 +12,10 @@ import CoreData
 
 struct OfflineAvailablePlatformsSheetsView: View {
     @State var codeVerifier: String = ""
-    var title: LocalizedStringKey = "Compose for Platform"
-    var titleRevoke: LocalizedStringKey = "Revoke Platforms"
-    @State var description: LocalizedStringKey = "Select a platform to send an example message - you can send a message to yourself"
-    @State var descriptionRevoke: LocalizedStringKey = "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform."
+    var title: String = String(localized:"Compose for Platform", comment: "Title for page showing the platform to compose a message for")
+    var titleRevoke: String = String(localized:"Revoke Platforms", comment: "Title for page showing the platforms to revoke an account for")
+    var description: String = String(localized:"Select a platform to send an example message - you can send a message to yourself", comment: "Description asking a user to select a platform to send an example message")
+    var descriptionRevoke: String = String(localized:"Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform.", comment: "Asks the user to select a platform they would like to revoke accounts from, and explains that the next screen will allow them to choose which account to revoke")
     @State var isRevoke: Bool = false
     
     var body: some View {
@@ -32,8 +32,8 @@ struct OfflineAvailablePlatformsSheetsView: View {
 struct OnlineAvailablePlatformsSheetsView: View {
     @Binding var codeVerifier: String
     
-    var title: LocalizedStringKey = "Available Platforms"
-    var description: LocalizedStringKey = "Select a platform to save it for offline use"
+    var title: String = String(localized: "Available Platforms", comment: "Title showing available platforms which can be saved for offline use" )
+    var description: String = String(localized:"Select a platform to save it for offline use", comment: "Description showing available platforms which can be saved for offline use")
     
     var body: some View {
         AvailablePlatformsSheetsView(
@@ -61,8 +61,8 @@ struct AvailablePlatformsSheetsView: View {
     
     @Binding var codeVerifier: String
     
-    var title: LocalizedStringKey
-     var description: LocalizedStringKey
+    var title: String
+    var description: String
     
     @State var type: TYPE = TYPE.AVAILABLE
     @Environment(\.openURL) var openURL

--- a/SMSWithoutBorders-Production/Views/SheetViews/AvailablePlatformsSheetsView.swift
+++ b/SMSWithoutBorders-Production/Views/SheetViews/AvailablePlatformsSheetsView.swift
@@ -12,10 +12,10 @@ import CoreData
 
 struct OfflineAvailablePlatformsSheetsView: View {
     @State var codeVerifier: String = ""
-    @State var title: String = "Compose for platform"
-    @State var titleRevoke: String = "Revoke Platforms"
-    @State var description: String = "Select a platform to send an example message - you can send a message to yourself"
-    @State var descriptionRevoke: String = "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform."
+    var title: LocalizedStringKey = "Compose for Platform"
+    var titleRevoke: LocalizedStringKey = "Revoke Platforms"
+    @State var description: LocalizedStringKey = "Select a platform to send an example message - you can send a message to yourself"
+    @State var descriptionRevoke: LocalizedStringKey = "Choose the platform you will like to revoke accounts from. Next screen will let you choose which account to revoke for the platform."
     @State var isRevoke: Bool = false
     
     var body: some View {
@@ -32,8 +32,8 @@ struct OfflineAvailablePlatformsSheetsView: View {
 struct OnlineAvailablePlatformsSheetsView: View {
     @Binding var codeVerifier: String
     
-    @State var title = "Available Platforms"
-    @State var description = "Select a platform to save it for offline use"
+    var title: LocalizedStringKey = "Available Platforms"
+    var description: LocalizedStringKey = "Select a platform to save it for offline use"
     
     var body: some View {
         AvailablePlatformsSheetsView(
@@ -61,8 +61,8 @@ struct AvailablePlatformsSheetsView: View {
     
     @Binding var codeVerifier: String
     
-    @State var title: String
-    @State var description: String
+    var title: LocalizedStringKey
+     var description: LocalizedStringKey
     
     @State var type: TYPE = TYPE.AVAILABLE
     @Environment(\.openURL) var openURL

--- a/SMSWithoutBorders-Production/Views/SheetViews/LoginSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/SheetViews/LoginSheetView.swift
@@ -145,7 +145,7 @@ struct LoginSheetView: View {
                                 }
                             }
                         } label: {
-                            Text("Login")
+                            Text("Log in")
                                 .bold()
                                 .frame(maxWidth: .infinity, maxHeight: 35)
 //                                .frame(width: 200 , height: 50, alignment: .center)
@@ -161,7 +161,7 @@ struct LoginSheetView: View {
                             Button {
                                 
                             } label: {
-                                Text("Create account")
+                                Text("Create Account")
                                     .bold()
                             }
                         }

--- a/SMSWithoutBorders-Production/Views/SheetViews/SignupSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/SheetViews/SignupSheetView.swift
@@ -119,7 +119,7 @@ struct SignupSheetView: View {
                         .frame(width: 75, height: 75)
                         .padding()
 
-                    Text("Create account")
+                    Text("Create Account")
                         .font(.title)
                         .bold()
                         .padding()
@@ -213,7 +213,7 @@ struct SignupSheetView: View {
                                 }
                             }
                         } label: {
-                            Text("Create account")
+                            Text("Create Account")
                                 .bold()
                                 .frame(maxWidth: .infinity, maxHeight: 35)
                         }

--- a/SMSWithoutBorders-Production/Views/SheetViews/SignupSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/SheetViews/SignupSheetView.swift
@@ -123,11 +123,9 @@ struct SignupSheetView: View {
                         .font(.title)
                         .bold()
                         .padding()
+         
+                    Text(String(localized:"If you don't have an account,\nPlease create one to save your platforms", comment: "Explains that you need to create an account to save your platforms if you don't have an account already")).multilineTextAlignment(.center)
                     
-                    Group {
-                        Text("If you don't have an account")
-                        Text("Please create one to save your platforms")
-                    }
                     .foregroundStyle(.secondary)
                     .font(.subheadline)
                 }


### PR DESCRIPTION
This PR sets up localisation for the RelaySMS iOS app, 
Initialises strings for localisation, with helpful comments for translators, and adds translation strings for the following languages.

- French
- Arabic
- Persian
- German
- Spanish
- Swahili
- Turkish