### PR TITLE
Add password visibility icons to password fields

### DIFF
--- a/SMSWithoutBorders-Production/Views/Auth/Components/PasswordField.swift
+++ b/SMSWithoutBorders-Production/Views/Auth/Components/PasswordField.swift
@@ -1,0 +1,41 @@
+//
+//  PasswordField.swift
+//  SMSWithoutBorders-Production
+//
+//  Created by Nui Lewis on 04/04/2025.
+//
+
+import SwiftUI
+
+struct PasswordField: View {
+    var placeholder: String?
+    @Binding var text: String
+    @State private var showPassword: Bool = false
+    @FocusState private var focus1: Bool
+    @FocusState private var focus2: Bool
+
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            TextField(placeholder ?? "Password", text: $text)
+                .textInputAutocapitalization(.never)
+                .textContentType(.password)
+                .autocorrectionDisabled(true)
+                .focused($focus1)
+                .opacity(showPassword ? 1 : 0)
+            SecureField(placeholder ?? "Password", text: $text)
+                .textInputAutocapitalization(.never)
+                .textContentType(.password).focused($focus2)
+                .autocorrectionDisabled(true)
+                .opacity(showPassword ? 0 : 1)
+        }.overlay(alignment: .trailing) {
+            Image(systemName: showPassword ? "eye.slash": "eye").onTapGesture {
+                showPassword.toggle()
+                if showPassword { focus1 = true}
+                else {focus2 = true}
+            }
+        }
+        
+    }
+}
+

--- a/SMSWithoutBorders-Production/Views/Auth/LoginSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/Auth/LoginSheetView.swift
@@ -134,9 +134,8 @@ struct LoginSheetView: View {
                         .padding(.top, 25)
                         .font(.subheadline)
                         .frame(maxWidth: .infinity, alignment: .trailing)
-                        
-                        SecureField("Password", text: $password)
-                            .padding(.bottom, 10)
+                    
+                        PasswordField(text: $password)
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                     }
                     .padding()
@@ -243,3 +242,8 @@ struct LoginSheetView_Preview: PreviewProvider {
         )
     }
 }
+
+
+
+
+

--- a/SMSWithoutBorders-Production/Views/Auth/PhoneNumberSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/Auth/PhoneNumberSheetView.swift
@@ -50,7 +50,7 @@ struct PhoneNumberCodeEntryView: View {
                 )
             
             if havePassword {
-                SecureField("Enter password", text: $password)
+                PasswordField(placeholder: "Enter password", text: $password)
                     .padding()
                     .controlSize(.large)
                     .overlay(

--- a/SMSWithoutBorders-Production/Views/Auth/RecoverySheetView.swift
+++ b/SMSWithoutBorders-Production/Views/Auth/RecoverySheetView.swift
@@ -121,11 +121,11 @@ struct RecoverySheetView: View {
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                             .padding(.bottom, 20)
                         
-                        SecureField("Password", text: $password)
+                        PasswordField(placeholder: "Password", text: $password)
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                             .padding(.bottom, 20)
                         
-                        SecureField("Re-enter password", text: $rePassword)
+                        PasswordField(placeholder: "Re-enter password", text: $rePassword)
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                         if passwordsNotMatch {
                             Text("Passwords don't match")

--- a/SMSWithoutBorders-Production/Views/Auth/SignupSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/Auth/SignupSheetView.swift
@@ -171,11 +171,11 @@ struct SignupSheetView: View {
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                             .padding(.bottom, 20)
                         
-                        SecureField("Password", text: $password)
+                        PasswordField( placeholder: "Password", text: $password)
                         Rectangle().frame(height: 1).foregroundColor(.secondary)
                             .padding(.bottom, 20)
                         
-                        SecureField("Re-enter password", text: $rePassword)
+                        PasswordField(placeholder: "Re-enter password", text: $rePassword)
                         Group {
                             Rectangle().frame(height: 1).foregroundColor(.secondary)
                             if passwordsNotMatch {


### PR DESCRIPTION
The changes introduce a new `PasswordField` component that replaces the standard `SecureField` in several views (`SignupSheetView`, `LoginSheetView`, `PhoneNumberSheetView`, and `RecoverySheetView`). This new component allows the user to toggle the visibility of the password field.
Fixes: #9 